### PR TITLE
Fix $RECYCLE.BIN Handling

### DIFF
--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -26,6 +26,19 @@ func TestOpenIgnoreFile(t *testing.T) {
 	defer public.Close()
 }
 
+func TestOpenRecycleBin(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".heheignore"), []byte("\\$RECYCLE.BIN\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "$RECYCLE.BIN"), []byte("shh"), 0644)
+
+	hfs := Dir(dir)
+
+	_, err := hfs.Open("/$RECYCLE.BIN")
+	if err == nil {
+		t.Fatal("expected error when opening ignored file $RECYCLE.BIN")
+	}
+}
+
 func TestOpenErr(t *testing.T) {
 	dir := t.TempDir()
 	hfs := Dir(dir)


### PR DESCRIPTION
Fixes #1.
There is actually nothing to be done, unless you wanna poke around [https://github.com/wsand02/go-gitignore/blob/master/ignore.go](https://github.com/wsand02/go-gitignore/blob/master/ignore.go), you simply have to prefix `$RECYCLE.BIN` with a backslash like this `\$RECYCLE.BIN` in your heheignore files.
Added test case for this scenario.