### PR TITLE
Fix 404 for emoji/special characters in gallery filenames

### DIFF
--- a/internal/handlers/gallery.go
+++ b/internal/handlers/gallery.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -32,9 +33,11 @@ func (gc *GalleryContext) GetBreadcrumbs() []string {
 func (gc *GalleryContext) BreadcrumbToUrl(i int) string {
 	crumbs := gc.GetBreadcrumbs()[1 : i+1]
 	pcrumbs := []string{"?path="}
-	pcrumbs = append(pcrumbs, crumbs...)
-	url := strings.Join(pcrumbs, "/")
-	urla := strings.Join([]string{url, "/"}, "")
+	for _, c := range crumbs {
+		pcrumbs = append(pcrumbs, url.QueryEscape(c))
+	}
+	u := strings.Join(pcrumbs, "/")
+	urla := strings.Join([]string{u, "/"}, "")
 	return urla
 }
 

--- a/internal/models/gallery.go
+++ b/internal/models/gallery.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -58,25 +59,45 @@ func (gi *GalleryItem) IsResizable() bool {
 	}
 }
 
+// escapeQueryPath percent-encodes each path segment for use as a ?path= query
+// value, leaving the separating slashes intact so the path stays readable.
+func escapeQueryPath(p string) string {
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		segs[i] = url.QueryEscape(s)
+	}
+	return strings.Join(segs, "/")
+}
+
+// escapeURLPath percent-encodes each path segment for use in a /fs/... URL path,
+// leaving the separating slashes intact.
+func escapeURLPath(p string) string {
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		segs[i] = url.PathEscape(s)
+	}
+	return strings.Join(segs, "/")
+}
+
 func (gi *GalleryItem) GetUrl() string {
 	if gi.IsDir {
-		return strings.Join([]string{"?path=", gi.Path, gi.Filename, "/"}, "")
+		return strings.Join([]string{"?path=", escapeQueryPath(gi.Path + gi.Filename), "/"}, "")
 	}
-	return strings.Join([]string{"/fs", gi.Path, gi.Filename}, "")
+	return strings.Join([]string{"/fs", escapeURLPath(gi.Path + gi.Filename)}, "")
 }
 
 func (gi *GalleryItem) GetPath() string {
-	return strings.Join([]string{"/fs", gi.Path}, "")
+	return strings.Join([]string{"/fs", escapeURLPath(gi.Path)}, "")
 }
 
 func (gi *GalleryItem) GetPostLink() string {
-	return strings.Join([]string{"/post/", "?path=", gi.Path, gi.Filename}, "")
+	return strings.Join([]string{"/post/", "?path=", escapeQueryPath(gi.Path + gi.Filename)}, "")
 }
 
 func (gi *GalleryItem) GetResized() string {
-	return strings.Join([]string{"/resize/", "?path=", gi.Path, gi.Filename}, "")
+	return strings.Join([]string{"/resize/", "?path=", escapeQueryPath(gi.Path + gi.Filename)}, "")
 }
 
 func (gi *GalleryItem) GetVidThumb() string {
-	return strings.Join([]string{"/vidthumb/", "?path=", gi.Path, gi.Filename}, "")
+	return strings.Join([]string{"/vidthumb/", "?path=", escapeQueryPath(gi.Path + gi.Filename)}, "")
 }

--- a/internal/models/gallery_test.go
+++ b/internal/models/gallery_test.go
@@ -174,6 +174,27 @@ func TestGalleryItem_GetUrl(t *testing.T) {
 			isDir:    true,
 			want:     "?path=/folder/lefolder/",
 		},
+		{
+			name:     "emoji file",
+			path:     "/folder/",
+			filename: "😀.jpg",
+			isDir:    false,
+			want:     "/fs/folder/%F0%9F%98%80.jpg",
+		},
+		{
+			name:     "space file",
+			path:     "/folder/",
+			filename: "a b.png",
+			isDir:    false,
+			want:     "/fs/folder/a%20b.png",
+		},
+		{
+			name:     "emoji folder",
+			path:     "/folder/",
+			filename: "😀",
+			isDir:    true,
+			want:     "?path=/folder/%F0%9F%98%80/",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -196,6 +217,11 @@ func TestGalleryItem_GetPath(t *testing.T) {
 			name: "Path",
 			path: "/hello/",
 			want: "/fs/hello/",
+		},
+		{
+			name: "emoji path",
+			path: "/hello/😀.jpg",
+			want: "/fs/hello/%F0%9F%98%80.jpg",
 		},
 	}
 	for _, tt := range tests {
@@ -222,6 +248,24 @@ func TestGalleryItem_GetPostLink(t *testing.T) {
 			filename: "hellosir.jpeg",
 			want:     "/post/?path=/hellothere/hellosir.jpeg",
 		},
+		{
+			name:     "emoji",
+			path:     "/hellothere/",
+			filename: "😀.jpg",
+			want:     "/post/?path=/hellothere/%F0%9F%98%80.jpg",
+		},
+		{
+			name:     "plus",
+			path:     "/hellothere/",
+			filename: "c++.png",
+			want:     "/post/?path=/hellothere/c%2B%2B.png",
+		},
+		{
+			name:     "space",
+			path:     "/hellothere/",
+			filename: "a b.png",
+			want:     "/post/?path=/hellothere/a+b.png",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -247,6 +291,12 @@ func TestGalleryItem_GetResized(t *testing.T) {
 			filename: "hellosir.jpeg",
 			want:     "/resize/?path=/hellothere/hellosir.jpeg",
 		},
+		{
+			name:     "emoji",
+			path:     "/hellothere/",
+			filename: "😀.jpg",
+			want:     "/resize/?path=/hellothere/%F0%9F%98%80.jpg",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -271,6 +321,12 @@ func TestGalleryItem_GetVidThumb(t *testing.T) {
 			path:     "/hellothere/",
 			filename: "hellosir.mp4",
 			want:     "/vidthumb/?path=/hellothere/hellosir.mp4",
+		},
+		{
+			name:     "emoji",
+			path:     "/hellothere/",
+			filename: "😀.mp4",
+			want:     "/vidthumb/?path=/hellothere/%F0%9F%98%80.mp4",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/wsand02/heheserver/internal/config"
@@ -104,5 +105,52 @@ func TestGalleryServerMode(t *testing.T) {
 	defer resp.Body.Close()
 	if http.StatusOK != resp.StatusCode {
 		t.Fatal("Status not OK")
+	}
+}
+
+// TestGallerySpecialCharFilenames reproduces issue #13: files whose names contain
+// emoji or URL-significant characters must be reachable through the gallery.
+func TestGallerySpecialCharFilenames(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"😀.jpg", "c++.png", "a b.png"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("data"), 0644); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	ts := testServer(t, dir, true, false)
+	client := ts.Client()
+
+	// The gallery page must not emit raw special chars into the links.
+	resp, err := client.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	for _, raw := range []string{"path=/c++.png", "path=/a b.png"} {
+		if strings.Contains(string(body), raw) {
+			t.Fatalf("gallery emitted unescaped link containing %q", raw)
+		}
+	}
+
+	// Each generated link must resolve to a real file (200), not 404.
+	cases := []string{
+		"/post/?path=/%F0%9F%98%80.jpg",
+		"/fs/%F0%9F%98%80.jpg",
+		"/post/?path=/c%2B%2B.png",
+		"/fs/c%2B%2B.png",
+		"/post/?path=/a%20b.png",
+		"/fs/a%20b.png",
+	}
+	for _, u := range cases {
+		resp, err := client.Get(ts.URL + u)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s => %d, want 200", u, resp.StatusCode)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #13 — navigating to a file whose name contains an emoji or other special/UTF-8 characters returned a 404 in the gallery view.

**Root cause:** All gallery links were built by raw string concatenation with no URL encoding, and templates render via `text/template` (no contextual escaping, unlike `html/template`). Filenames landed verbatim in `href`/`src` and in the `?path=` query value, so URL-significant or non-ASCII characters broke routing:
- Query context (`/post/?path=…`, `/resize/`, `/vidthumb/`, dir `?path=…`): a literal `+` decodes to a space server-side, and `#`, `&`, `?`, `%` break parsing → wrong/no file opened → 404.
- Path context (`/fs/…`): unescaped special chars similarly mis-route.

## Fix

Percent-encode each path segment per context, keeping slashes literal so paths stay readable:
- `escapeQueryPath` (`url.QueryEscape` per segment) for `?path=` links
- `escapeURLPath` (`url.PathEscape` per segment) for `/fs/` links

Applied across `GetUrl`, `GetPath`, `GetPostLink`, `GetResized`, `GetVidThumb` (`internal/models/gallery.go`) and `BreadcrumbToUrl` (`internal/handlers/gallery.go`).

## Tests

Written failing-first (TDD):
- Emoji / `+` / space cases added to the `internal/models` table tests.
- End-to-end `TestGallerySpecialCharFilenames` in `internal/server/server_test.go`: serves files named `😀.jpg`, `c++.png`, `a b.png`, asserts the gallery emits no unescaped links, and that every generated `/post/` and `/fs/` link returns HTTP 200.

`go test ./...` passes; `gofmt`/`go vet` clean. Also verified manually by running the server against a directory containing these files — all links return 200 instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)