### PR TITLE
Switch gallery templates to html/template for auto-escaping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,11 @@ Entry point `main.go` → `config.ParseFromFlags()` → `server.NewServer(cfg)` 
 
 **Thumbnailing** (`internal/resize`, `internal/vidthumb`, plus the matching handlers): prefers shelling out to `ffmpeg` when it's on PATH (`utils.FFmpegExists()` is checked once at config time into `Config.FFmpegExists`). Image resize falls back to a pure-Go `golang.org/x/image/draw` path when ffmpeg is absent; video thumbnails require ffmpeg and the route is only registered when it exists.
 
-**View layer**: `internal/models/gallery.go` (`GalleryItem` with type predicates like `IsImage`/`IsVideo` and URL builders) feeds `internal/templates` (Go `text/template` files embedded via `//go:embed *.html`). Custom template funcs for pagination/arithmetic live in `templates.go`.
+**View layer**: `internal/models/gallery.go` (`GalleryItem` with type predicates like `IsImage`/`IsVideo` and URL builders) feeds `internal/templates` (Go `html/template` files embedded via `//go:embed *.html`). Custom template funcs for pagination/arithmetic live in `templates.go`.
 
 ## Conventions and gotchas
 
 - **Path handling is security-sensitive.** URL/query path escaping is centralized in `models.escapeQueryPath`/`escapeURLPath`; the fs and vidthumb handlers replicate Go stdlib's `Open` localization logic (`path.Clean`, `filepath.Localize`) to avoid traversal. Preserve this when touching path construction — emoji/special-character filenames have already caused 404 regressions.
-- Templates use `text/template`, not `html/template` — output is not auto-escaped.
+- Templates use `html/template`, so output is contextually auto-escaped (user-controlled filenames render as inert text, not live HTML). This does **not** replace the manual URL escaping: the URL builders (`escapeQueryPath`/`escapeURLPath`, `BreadcrumbToUrl`, `pageURL`) do the semantic query-value vs. path-segment encoding, and `html/template` preserves those already-escaped `%XX` values while adding HTML-context escaping on top. Keep both layers.
 - New file-type support usually means updating the predicate methods on `GalleryItem` and the relevant template.
 - Start bug fixes with a failing test derived from the issue (see the race tests in `internal/ignore` and `internal/fs` for the pattern).

--- a/internal/handlers/gallery_render_test.go
+++ b/internal/handlers/gallery_render_test.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"html"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wsand02/heheserver/internal/models"
+	"github.com/wsand02/heheserver/internal/templates"
+)
+
+// renderList renders the "list" template with the given context and returns the body.
+func renderList(t *testing.T, gc *GalleryContext) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	templates.RenderTemplate(w, "list", gc)
+	if w.Code != 200 {
+		t.Fatalf("render list: status %d, body: %s", w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+func renderPost(t *testing.T, pc *PostContext) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	templates.RenderTemplate(w, "post", pc)
+	if w.Code != 200 {
+		t.Fatalf("render post: status %d, body: %s", w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+// TestListEscapesFilename is the reason for the html/template switch: a
+// user-controlled filename containing markup must be rendered as inert text, not
+// injected as live HTML.
+func TestListEscapesFilename(t *testing.T) {
+	gc := &GalleryContext{
+		Path:        "/",
+		CurrentPage: 1,
+		MaxPage:     1,
+		Items: []models.GalleryItem{
+			{Filename: "<script>alert(1)</script>.txt", Path: "/"},
+		},
+	}
+	body := renderList(t, gc)
+
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Errorf("filename rendered as live HTML (XSS): body contains raw <script>")
+	}
+	if !strings.Contains(body, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Errorf("expected HTML-escaped filename in output, got:\n%s", body)
+	}
+}
+
+// TestListSpecialCharURLsNotBroken guards the CLAUDE.md special-char 404 class:
+// filenames with spaces/emoji must still produce correctly percent-encoded URLs
+// and must not be double-encoded or filtered to #ZgotmplZ.
+func TestListSpecialCharURLsNotBroken(t *testing.T) {
+	gc := &GalleryContext{
+		Path:        "/sub dir/",
+		CurrentPage: 1,
+		MaxPage:     1,
+		Items: []models.GalleryItem{
+			{Filename: "a b 😀.txt", Path: "/sub dir/"},
+		},
+	}
+	// html/template HTML-encodes some URL chars in attributes (e.g. + -> &#43;);
+	// the browser decodes those before using the URL, so assert against the
+	// effective (HTML-unescaped) URLs — this is what actually reaches the server.
+	body := html.UnescapeString(renderList(t, gc))
+
+	if strings.Contains(body, "ZgotmplZ") {
+		t.Errorf("a URL was filtered to #ZgotmplZ:\n%s", body)
+	}
+	// /fs/ path URL from GetUrl: space -> %20, emoji percent-encoded, no double %25.
+	if !strings.Contains(body, "/fs/sub%20dir/a%20b%20") {
+		t.Errorf("expected percent-encoded /fs/ URL, got:\n%s", body)
+	}
+	// ?path= post link from GetPostLink: QueryEscape encodes space -> +.
+	if !strings.Contains(body, "?path=/sub+dir/a+b+") {
+		t.Errorf("expected query-escaped post link, got:\n%s", body)
+	}
+	if strings.Contains(body, "%25") {
+		t.Errorf("URL appears double-encoded (contains %%25):\n%s", body)
+	}
+}
+
+// TestPostSpecialCharURLsNotBroken does the same guard for the single-item view.
+func TestPostSpecialCharURLsNotBroken(t *testing.T) {
+	pc := &PostContext{models.GalleryItem{Filename: "a b 😀.txt", Path: "/sub dir/"}}
+	body := html.UnescapeString(renderPost(t, pc))
+
+	if strings.Contains(body, "ZgotmplZ") {
+		t.Errorf("a URL was filtered to #ZgotmplZ:\n%s", body)
+	}
+	if !strings.Contains(body, "/fs/sub%20dir/") {
+		t.Errorf("expected percent-encoded /fs/ path URL, got:\n%s", body)
+	}
+	if strings.Contains(body, "%25") {
+		t.Errorf("URL appears double-encoded (contains %%25):\n%s", body)
+	}
+}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -3,10 +3,10 @@ package templates
 import (
 	"embed"
 	"fmt"
+	"html/template"
 	"io/fs"
 	"net/http"
 	"net/url"
-	"text/template"
 )
 
 //go:embed *.html


### PR DESCRIPTION
## What & why

The gallery renders user-controlled filenames (and filename-derived URLs) into `list.html`/`post.html` via `text/template`, which does **no escaping**. A file named e.g. `` `<script>alert(1)</script>.png` `` was injected verbatim as live HTML — a stored-XSS vector (the server has no auth). Switching the template package to `html/template` gives contextual auto-escaping, so such filenames render as inert text.

## Key point: the existing URL escaping is kept

The manual builders and `html/template` are complementary, not redundant:

- **Manual builders do semantic encoding** — `escapeQueryPath`/`escapeURLPath`, `BreadcrumbToUrl`, `pageURL` know whether a filename lands in a `?path=` query value or a `/fs/` path segment and encode structural delimiters (`/ & ? = # +`) accordingly.
- **`html/template` does generic output normalization** — it preserves existing `%XX` escapes (no double-encoding) and only adds HTML-context escaping on top.

Dropping the manual layer and relying on `html/template` alone would reintroduce the special-char 404 class documented in `CLAUDE.md` (e.g. `a&b=c.png` → bogus query params). Both layers stay.

One behavioural note: `+` inside a query href is emitted as the entity `&#43;`; the browser decodes it back to `+` before requesting, so the effective URL is unchanged.

## Changes

- `internal/templates/templates.go` — import swap `text/template` → `html/template` (the entire production change; APIs are identical).
- `internal/handlers/gallery_render_test.go` (new) — an XSS-escaping test (fails on `text/template`, passes now) plus special-char/emoji URL regression guards for the list and post views.
- `CLAUDE.md` — updated the template notes to reflect `html/template` and to record that the manual URL escaping must be kept.

## Verification

- `go build -v ./...`, `go test -race ./...`, `go vet ./...` — all clean.
- Live smoke test: a resize-enabled gallery with an emoji file, a space-in-name file, and `<script>alert(1)<x>.png` — the malicious name is escaped in both views (raw-injection count 0) and every special-character file returns HTTP 200 (no 404 regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)