### PR TITLE
Fix duplicated empty breadcrumbs on gallery pages

### DIFF
--- a/internal/handlers/gallery.go
+++ b/internal/handlers/gallery.go
@@ -25,13 +25,23 @@ type GalleryContext struct {
 	MaxPage      int
 }
 
+// GetBreadcrumbs returns the non-empty path segments. Splitting on "/" yields
+// empty leading/trailing segments (e.g. "/" -> ["", ""], "/foo/bar/" ->
+// ["", "foo", "bar", ""]); those would render as blank breadcrumb items, so
+// they are dropped here. The hardcoded "Home" crumb in the template covers the
+// root, so an empty slice is correct for "/".
 func (gc *GalleryContext) GetBreadcrumbs() []string {
-	return strings.Split(gc.Path, "/")
-
+	var parts []string
+	for _, p := range strings.Split(gc.Path, "/") {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
 }
 
 func (gc *GalleryContext) BreadcrumbToUrl(i int) string {
-	crumbs := gc.GetBreadcrumbs()[1 : i+1]
+	crumbs := gc.GetBreadcrumbs()[: i+1]
 	pcrumbs := []string{"?path="}
 	for _, c := range crumbs {
 		pcrumbs = append(pcrumbs, url.QueryEscape(c))

--- a/internal/handlers/gallery_render_test.go
+++ b/internal/handlers/gallery_render_test.go
@@ -31,6 +31,29 @@ func renderPost(t *testing.T, pc *PostContext) string {
 	return w.Body.String()
 }
 
+// countBreadcrumbs returns how many breadcrumb <li> items the rendered body has.
+func countBreadcrumbs(body string) int {
+	return strings.Count(body, `class="breadcrumb-item"`)
+}
+
+// TestListRootBreadcrumbsNoDuplicates guards against the split("/", "/") == ["", ""]
+// bug that rendered "Home" plus two empty breadcrumb items on the root page.
+func TestListRootBreadcrumbsNoDuplicates(t *testing.T) {
+	gc := &GalleryContext{Path: "/", CurrentPage: 1, MaxPage: 1}
+	if n := countBreadcrumbs(renderList(t, gc)); n != 1 {
+		t.Errorf("root page: expected 1 breadcrumb (Home), got %d", n)
+	}
+}
+
+// TestListNestedBreadcrumbs checks a nested path yields exactly Home + one crumb
+// per path segment, with no stray empty leading crumb.
+func TestListNestedBreadcrumbs(t *testing.T) {
+	gc := &GalleryContext{Path: "/foo/bar/", CurrentPage: 1, MaxPage: 1}
+	if n := countBreadcrumbs(renderList(t, gc)); n != 3 {
+		t.Errorf("/foo/bar/: expected 3 breadcrumbs (Home, foo, bar), got %d", n)
+	}
+}
+
 // TestListEscapesFilename is the reason for the html/template switch: a
 // user-controlled filename containing markup must be rendered as inert text, not
 // injected as live HTML.


### PR DESCRIPTION
## Problem

The gallery root page (`/`) rendered duplicated, blank breadcrumbs. `GalleryContext.Path` is `"/"` at the root, and `GetBreadcrumbs()` did a bare `strings.Split("/", "/")` → `["", ""]`. Since `list.html` hardcodes a **"Home"** crumb and then ranges over that split, the root showed **Home + two empty breadcrumb items**.

Nested paths had the same class of bug: the leading empty split segment (and the trailing one when the path ends in `/`) rendered as blank crumbs too — e.g. `/foo/bar/` produced Home + 4 items instead of Home + `foo` + `bar`.

## Fix

- `GetBreadcrumbs()` now drops empty segments, so `/` → `[]` (covered by the hardcoded Home crumb) and `/foo/bar/` → `["foo", "bar"]`.
- `BreadcrumbToUrl` slice adjusted from `[1:i+1]` to `[:i+1]` since there's no longer a leading empty element to skip. Generated `?path=…` URLs are unchanged.

## Tests

Added `TestListRootBreadcrumbsNoDuplicates` (root → 1 crumb) and `TestListNestedBreadcrumbs` (`/foo/bar/` → 3 crumbs), both of which failed before the change. Full suite passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)