### PR TITLE
Add unit tests across previously-untested packages (#3)

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"image"
+	"testing"
+
+	ignore "github.com/wsand02/go-gitignore"
+)
+
+func TestSizeToNCMB(t *testing.T) {
+	bytes, nc := sizeToNCMB(16)
+	if bytes != 16*1024*1024 {
+		t.Errorf("bytes = %d, want %d", bytes, 16*1024*1024)
+	}
+	if nc != 16*10000 {
+		t.Errorf("numCounters = %d, want %d", nc, 16*10000)
+	}
+}
+
+func TestIgnoreCacheRoundtrip(t *testing.T) {
+	if err := NewIgnoreCache(1); err != nil {
+		t.Fatal(err)
+	}
+	gi := ignore.CompileIgnoreLines("*.tmp")
+	c := GetIgnoreCache()
+	c.Set("key", gi, 1)
+	c.Wait() // ristretto applies Set asynchronously
+
+	got, ok := c.Get("key")
+	if !ok {
+		t.Fatal("expected cached ignore value, got miss")
+	}
+	if got != gi {
+		t.Error("cached ignore value differs from stored value")
+	}
+}
+
+func TestResizeCacheRoundtrip(t *testing.T) {
+	if err := NewResizeCache(1); err != nil {
+		t.Fatal(err)
+	}
+	item := ResizeCacheItem{Image: image.NewRGBA(image.Rect(0, 0, 2, 2)), Transparent: true}
+	c := GetResizeCache()
+	c.Set("key", item, 4)
+	c.Wait()
+
+	got, ok := c.Get("key")
+	if !ok {
+		t.Fatal("expected cached resize item, got miss")
+	}
+	if !got.Transparent || got.Image == nil {
+		t.Errorf("cached resize item not preserved: %+v", got)
+	}
+}
+
+func TestVidThumbCacheRoundtrip(t *testing.T) {
+	if err := NewVidThumbCache(1); err != nil {
+		t.Fatal(err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	c := GetVidThumbCache()
+	c.Set("key", img, 4)
+	c.Wait()
+
+	got, ok := c.Get("key")
+	if !ok {
+		t.Fatal("expected cached thumbnail, got miss")
+	}
+	if got == nil {
+		t.Error("cached thumbnail is nil")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewConfigValid(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := NewConfig(3400, 64, true, false, dir, "0.0.0.0", 16, 1000, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != 3400 || cfg.Split != 64 || !cfg.Gallery || cfg.Resize {
+		t.Errorf("config fields not populated as expected: %+v", cfg)
+	}
+	if cfg.Directory != dir || cfg.Host != "0.0.0.0" {
+		t.Errorf("directory/host not populated: %+v", cfg)
+	}
+	if cfg.IgnoreCacheSize != 16 || cfg.ResizeCacheSize != 1000 || cfg.VidThumbCacheSize != 1000 {
+		t.Errorf("cache sizes not populated: %+v", cfg)
+	}
+}
+
+func TestNewConfigInvalidSplit(t *testing.T) {
+	dir := t.TempDir()
+	for _, split := range []int{0, -1} {
+		if _, err := NewConfig(3400, split, false, false, dir, "0.0.0.0", 16, 1000, 1000); err == nil {
+			t.Errorf("split %d: expected error, got nil", split)
+		}
+	}
+}
+
+func TestNewConfigMissingDirectory(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := NewConfig(3400, 64, false, false, missing, "0.0.0.0", 16, 1000, 1000); err == nil {
+		t.Error("expected error for missing directory, got nil")
+	}
+}
+
+func TestGetAddress(t *testing.T) {
+	c := &Config{Host: "127.0.0.1", Port: 8080}
+	if got := c.GetAddress(); got != "127.0.0.1:8080" {
+		t.Errorf("GetAddress() = %q, want %q", got, "127.0.0.1:8080")
+	}
+}

--- a/internal/handlers/gallery_test.go
+++ b/internal/handlers/gallery_test.go
@@ -1,0 +1,126 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/wsand02/heheserver/internal/cache"
+	"github.com/wsand02/heheserver/internal/config"
+	"github.com/wsand02/heheserver/internal/fs"
+)
+
+func TestGetBreadcrumbs(t *testing.T) {
+	cases := []struct {
+		path string
+		want []string
+	}{
+		{"/", nil},
+		{"/foo/bar/", []string{"foo", "bar"}},
+		{"/a", []string{"a"}},
+	}
+	for _, c := range cases {
+		gc := &GalleryContext{Path: c.path}
+		if got := gc.GetBreadcrumbs(); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("GetBreadcrumbs(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestBreadcrumbToUrl(t *testing.T) {
+	gc := &GalleryContext{Path: "/foo/bar/"}
+	if got := gc.BreadcrumbToUrl(0); got != "?path=/foo/" {
+		t.Errorf("BreadcrumbToUrl(0) = %q, want %q", got, "?path=/foo/")
+	}
+	if got := gc.BreadcrumbToUrl(1); got != "?path=/foo/bar/" {
+		t.Errorf("BreadcrumbToUrl(1) = %q, want %q", got, "?path=/foo/bar/")
+	}
+
+	// Special characters in a segment must be query-escaped.
+	special := &GalleryContext{Path: "/a b/"}
+	if got := special.BreadcrumbToUrl(0); got != "?path=/a+b/" {
+		t.Errorf("BreadcrumbToUrl(0) = %q, want %q", got, "?path=/a+b/")
+	}
+}
+
+// testHFS builds a HeheFS rooted at dir. The ignore cache must be initialized
+// because hfs.Open consults it.
+func testHFS(t *testing.T, dir string) *fs.HeheFS {
+	t.Helper()
+	if err := cache.NewIgnoreCache(1); err != nil {
+		t.Fatal(err)
+	}
+	hfs, ok := fs.Dir(dir).(*fs.HeheFS)
+	if !ok {
+		t.Fatal("fs.Dir did not return *HeheFS")
+	}
+	return hfs
+}
+
+func TestGalleryHandler(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	hfs := testHFS(t, dir)
+	cfg := &config.Config{Split: 64}
+
+	cases := []struct {
+		name       string
+		target     string
+		wantStatus int
+	}{
+		{"valid", "/?path=/", 200},
+		{"bad page (not a number)", "/?path=/&p=abc", 400},
+		{"page out of range", "/?path=/&p=999", 400},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", c.target, nil)
+			GalleryHandler(w, r, "/", hfs, cfg)
+			if w.Code != c.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", w.Code, c.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestGalleryHandlerEmptyDir(t *testing.T) {
+	hfs := testHFS(t, t.TempDir())
+	cfg := &config.Config{Split: 64}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/?path=/", nil)
+	GalleryHandler(w, r, "/", hfs, cfg)
+	if w.Code != 200 {
+		t.Errorf("empty dir: status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestPostHandler(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	hfs := testHFS(t, dir)
+	cfg := &config.Config{Split: 64}
+
+	// A file path renders successfully.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/post/?path=/hello.txt", nil)
+	PostHandler(w, r, "/hello.txt", hfs, cfg)
+	if w.Code != 200 {
+		t.Errorf("file: status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	// A directory path is rejected.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/post/?path=/", nil)
+	PostHandler(w, r, "/", hfs, cfg)
+	if w.Code != 400 {
+		t.Errorf("directory: status = %d, want 400", w.Code)
+	}
+}

--- a/internal/handlers/resize_test.go
+++ b/internal/handlers/resize_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wsand02/heheserver/internal/cache"
+	"github.com/wsand02/heheserver/internal/config"
+)
+
+func writePNG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{uint8(x % 256), uint8(y % 256), 64, 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResizeHandlerFallback(t *testing.T) {
+	if err := cache.NewResizeCache(1); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	writePNG(t, filepath.Join(dir, "pic.png"), 600, 400)
+	hfs := testHFS(t, dir) // also initializes the ignore cache
+	cfg := &config.Config{FFmpegExists: false}
+
+	// First request: generated via the pure-Go fallback and cached.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/resize/?path=/pic.png", nil)
+	ResizeHandler(w, r, "/pic.png", hfs, cfg)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if _, err := jpeg.Decode(bytes.NewReader(w.Body.Bytes())); err != nil {
+		t.Fatalf("response body is not a decodable JPEG: %v", err)
+	}
+	cache.GetResizeCache().Wait()
+
+	// Second request: served from cache.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/resize/?path=/pic.png", nil)
+	ResizeHandler(w, r, "/pic.png", hfs, cfg)
+	if w.Code != 200 {
+		t.Fatalf("cached status = %d, want 200", w.Code)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc == "" {
+		t.Error("expected Cache-Control header on cached response")
+	}
+	if _, err := jpeg.Decode(bytes.NewReader(w.Body.Bytes())); err != nil {
+		t.Fatalf("cached body is not a decodable JPEG: %v", err)
+	}
+}
+
+func TestResizeHandlerNotAnImage(t *testing.T) {
+	if err := cache.NewResizeCache(1); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.txt"), []byte("just some text, not an image at all"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	hfs := testHFS(t, dir)
+	cfg := &config.Config{FFmpegExists: false}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/resize/?path=/note.txt", nil)
+	ResizeHandler(w, r, "/note.txt", hfs, cfg)
+	if w.Code != 415 {
+		t.Errorf("status = %d, want 415", w.Code)
+	}
+}

--- a/internal/handlers/vidthumb_test.go
+++ b/internal/handlers/vidthumb_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"bytes"
+	"image/jpeg"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/wsand02/heheserver/internal/cache"
+	"github.com/wsand02/heheserver/internal/config"
+	"github.com/wsand02/heheserver/internal/utils"
+)
+
+func makeTestVideo(t *testing.T, path string) {
+	t.Helper()
+	cmd := exec.Command("ffmpeg", "-y", "-f", "lavfi",
+		"-i", "testsrc=duration=2:size=64x64:rate=10",
+		"-pix_fmt", "yuv420p", path)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to generate test video: %v\n%s", err, out)
+	}
+}
+
+func TestVidThumbHandler(t *testing.T) {
+	if !utils.FFmpegExists() {
+		t.Skip("ffmpeg not on PATH")
+	}
+	if err := cache.NewVidThumbCache(1); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	makeTestVideo(t, filepath.Join(dir, "clip.mp4"))
+	hfs := testHFS(t, dir) // also initializes the ignore cache
+	cfg := &config.Config{FFmpegExists: true}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/vidthumb/?path=/clip.mp4", nil)
+	VidThumbHandler(w, r, "/clip.mp4", hfs, cfg)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if _, err := jpeg.Decode(bytes.NewReader(w.Body.Bytes())); err != nil {
+		t.Fatalf("response body is not a decodable JPEG: %v", err)
+	}
+}
+
+func TestVidThumbHandlerNotAVideo(t *testing.T) {
+	if !utils.FFmpegExists() {
+		t.Skip("ffmpeg not on PATH")
+	}
+	if err := cache.NewVidThumbCache(1); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.txt"), []byte("not a video"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	hfs := testHFS(t, dir)
+	cfg := &config.Config{FFmpegExists: true}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/vidthumb/?path=/note.txt", nil)
+	VidThumbHandler(w, r, "/note.txt", hfs, cfg)
+	if w.Code != 415 {
+		t.Errorf("status = %d, want 415", w.Code)
+	}
+}

--- a/internal/resize/resize_test.go
+++ b/internal/resize/resize_test.go
@@ -1,0 +1,73 @@
+package resize
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wsand02/heheserver/internal/utils"
+)
+
+// makePNG returns a w x h PNG encoded into a buffer.
+func makePNG(t *testing.T, w, h int) *bytes.Buffer {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{uint8(x % 256), uint8(y % 256), 128, 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+func TestResizeImageFallback(t *testing.T) {
+	buf := makePNG(t, 600, 400)
+	dst, err := ResizeImageFallback(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dst.Bounds().Dx() != width {
+		t.Errorf("width = %d, want %d", dst.Bounds().Dx(), width)
+	}
+	// 600x400 has ratio 1.5, so target height = width / 1.5 = 200.
+	if dst.Bounds().Dy() != 200 {
+		t.Errorf("height = %d, want 200", dst.Bounds().Dy())
+	}
+}
+
+func TestResizeImageFallbackDecodeError(t *testing.T) {
+	if _, err := ResizeImageFallback(strings.NewReader("not an image")); err == nil {
+		t.Error("expected decode error for non-image input, got nil")
+	}
+}
+
+func TestResizeImageFFmpeg(t *testing.T) {
+	if !utils.FFmpegExists() {
+		t.Skip("ffmpeg not on PATH")
+	}
+	// Write a valid PNG to disk for ffmpeg to read. Only feed a decodable image:
+	// ResizeImage log.Fatals on a decode error.
+	path := filepath.Join(t.TempDir(), "src.png")
+	if err := os.WriteFile(path, makePNG(t, 600, 400).Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	img, err := ResizeImage(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if img == nil {
+		t.Fatal("expected a resized image, got nil")
+	}
+	if img.Bounds().Dx() != width {
+		t.Errorf("width = %d, want %d", img.Bounds().Dx(), width)
+	}
+}

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,0 +1,89 @@
+package templates
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPageURL(t *testing.T) {
+	cases := []struct {
+		path string
+		page int
+		want string
+	}{
+		{"", 1, "?"},
+		{"", 2, "?p=2"},
+		{"foo/bar", 1, "?path=foo%2Fbar"},
+	}
+	for _, c := range cases {
+		if got := pageURL(c.path, c.page); got != c.want {
+			t.Errorf("pageURL(%q, %d) = %q, want %q", c.path, c.page, got, c.want)
+		}
+	}
+
+	// Ordering of query values is not guaranteed, so assert on substrings.
+	got := pageURL("foo", 3)
+	if !strings.Contains(got, "path=foo") || !strings.Contains(got, "p=3") {
+		t.Errorf("pageURL(%q, %d) = %q, want it to contain path=foo and p=3", "foo", 3, got)
+	}
+}
+
+func TestSeq(t *testing.T) {
+	cases := []struct {
+		start, end int
+		want       []int
+	}{
+		{1, 3, []int{1, 2, 3}},
+		{3, 1, []int{}},
+		{2, 2, []int{2}},
+	}
+	for _, c := range cases {
+		if got := seq(c.start, c.end); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("seq(%d, %d) = %v, want %v", c.start, c.end, got, c.want)
+		}
+	}
+}
+
+func TestArithmeticHelpers(t *testing.T) {
+	if sub(5, 3) != 2 {
+		t.Errorf("sub(5,3) = %d, want 2", sub(5, 3))
+	}
+	if add(5, 3) != 8 {
+		t.Errorf("add(5,3) = %d, want 8", add(5, 3))
+	}
+	if !gt(5, 3) || gt(3, 5) || gt(3, 3) {
+		t.Error("gt behaves incorrectly")
+	}
+	if !lt(3, 5) || lt(5, 3) || lt(3, 3) {
+		t.Error("lt behaves incorrectly")
+	}
+	if !ge(3, 3) || !ge(5, 3) || ge(3, 5) {
+		t.Error("ge behaves incorrectly")
+	}
+	if !le(3, 3) || !le(3, 5) || le(5, 3) {
+		t.Error("le behaves incorrectly")
+	}
+}
+
+func TestStaticHandler(t *testing.T) {
+	ts := httptest.NewServer(StaticHandler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/static/glacialwisp.min.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected non-empty CSS body")
+	}
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"errors"
+	"image"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetCost(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 300, 200))
+	if got := GetCost(img); got != 300*200 {
+		t.Errorf("GetCost() = %d, want %d", got, 300*200)
+	}
+}
+
+func TestHttpLogErr(t *testing.T) {
+	w := httptest.NewRecorder()
+	HttpLogErr(w, errors.New("boom"), "something failed", http.StatusBadRequest)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if body := w.Body.String(); body != "something failed\n" {
+		t.Errorf("body = %q, want %q", body, "something failed\n")
+	}
+}
+
+func TestFFmpegExists(t *testing.T) {
+	// Result depends on the host; just assert it does not panic and returns a bool.
+	_ = FFmpegExists()
+}

--- a/internal/vidthumb/vidthumb_test.go
+++ b/internal/vidthumb/vidthumb_test.go
@@ -1,0 +1,38 @@
+package vidthumb
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/wsand02/heheserver/internal/utils"
+)
+
+// makeTestVideo generates a short test clip with ffmpeg and returns its path.
+func makeTestVideo(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "clip.mp4")
+	cmd := exec.Command("ffmpeg", "-y", "-f", "lavfi",
+		"-i", "testsrc=duration=2:size=64x64:rate=10",
+		"-pix_fmt", "yuv420p", path)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to generate test video: %v\n%s", err, out)
+	}
+	return path
+}
+
+func TestGenerateThumb(t *testing.T) {
+	if !utils.FFmpegExists() {
+		t.Skip("ffmpeg not on PATH")
+	}
+	img, err := GenerateThumb(makeTestVideo(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if img == nil {
+		t.Fatal("expected a thumbnail image, got nil")
+	}
+	if img.Bounds().Empty() {
+		t.Error("thumbnail has empty bounds")
+	}
+}


### PR DESCRIPTION
## Summary

Adds unit tests for the packages that had 0% (or near-0%) coverage, addressing issue #3. Follows the repo's existing conventions: `t.TempDir()` fixtures, `httptest`, table-driven cases, and passes `go test -race ./...` (matches CI).

**Coverage change** for previously-untested packages:

| Package | Before | After |
|---|---|---|
| `config` | 0% | 28% |
| `utils` | 0% | 85.7% |
| `templates` | 0% | 85.2% |
| `cache` | 0% | 80% |
| `resize` | 0% | 40.9% |
| `handlers` | 8.5% | 54.6% |

## What's covered

- **config** — `NewConfig` validation (bad split / missing dir), `GetAddress`
- **utils** — `GetCost`, `HttpLogErr`
- **templates** — `pageURL`, `seq`, arithmetic helpers, `StaticHandler`
- **cache** — `sizeToNCMB`, Set/Get roundtrips for all three caches
- **resize** — pure-Go `ResizeImageFallback` scaling math + decode-error path
- **handlers** — breadcrumb builders, `GalleryHandler` pagination edge cases (bad/out-of-range `p`, empty dir), `PostHandler`, `ResizeHandler` fallback + cache + 415 paths

## ffmpeg-dependent paths

`ResizeImage`, `GenerateThumb`, and `VidThumbHandler` are covered but guarded with `t.Skip` when ffmpeg is absent, so CI stays green either way. These add coverage on hosts where ffmpeg is present.

## Intentional gaps

- `config.ParseFromFlags` — mutates the global `flag` set; not worth the fragility.
- The `GetXCache`-before-init `log.Fatal` branches — would kill the test process.
- The pre-existing `log.Fatal`-on-decode-error in `resize.ResizeImage`/`vidthumb.GenerateThumb` was left as-is; tests only feed valid media. Returning the error instead is a reasonable follow-up.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)