### PR TITLE
Fix pagination arrow overflow on small screens (#6)

### DIFF
--- a/internal/templates/list.html
+++ b/internal/templates/list.html
@@ -83,13 +83,13 @@
 <ul class="pagination" style="justify-content: center; margin-top: 2rem">
   <!-- Previous -->
   {{ if gt .CurrentPage 1 }}
-  <li class="page-item page-prev">
+  <li class="page-item">
     <a href="{{ pageURL .Path (sub .CurrentPage 1) }}" aria-label="Previous">
       <i class="icon icon-arrow-left"></i>
     </a>
   </li>
   {{ else }}
-  <li class="page-item page-prev disabled">
+  <li class="page-item disabled">
     <a aria-disabled="true"><i class="icon icon-arrow-left"></i></a>
   </li>
   {{ end }}
@@ -112,13 +112,13 @@
 
   <!-- Next -->
   {{ if lt .CurrentPage .MaxPage }}
-  <li class="page-item page-next">
+  <li class="page-item">
     <a href="{{ pageURL .Path (add .CurrentPage 1) }}" aria-label="Next">
       <i class="icon icon-arrow-right"></i>
     </a>
   </li>
   {{ else }}
-  <li class="page-item page-next disabled">
+  <li class="page-item disabled">
     <a aria-disabled="true"><i class="icon icon-arrow-right"></i></a>
   </li>
   {{ end }}


### PR DESCRIPTION
## Summary

Fixes #6 — the gallery pagination bar overflowed horizontally on small screens (the forward/back arrows overflowed).

**Root cause:** The glacialwisp CSS framework defines two distinct pagination patterns — a **numeric bar** (every item is a plain `page-item`) and a **"Previous article / Next article"** two-block layout (`page-prev`/`page-next`, styled with `flex: 1 0 50%`). Our numeric bar in `internal/templates/list.html` mistakenly tagged the arrow items with `page-prev`/`page-next`, so the prev and next arrows each claimed 50% of the width and couldn't shrink (`flex-shrink: 0`). With `.pagination` set to no-wrap, the row overflowed horizontally on narrow (mobile) viewports.

**Fix:** Use plain `page-item` for the arrow `<li>` elements, matching the framework's documented numeric-pagination convention. The arrows now size to their icon like every other page item; no custom CSS needed. Arrow glyphs and the range/ellipsis logic are unchanged.

## Testing

- `go build -v ./...` and `go test -race ./...` — all packages pass.
- Ran the binary against a 30-page gallery (`-s 1`) and fetched a middle page: the rendered pagination now emits only `page-item` for the arrows, page numbers, and both `…` ellipses. The `flex: 1 0 50%` overflow driver is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)