### PR TITLE
Print clickable localhost/LAN links instead of raw bind address

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,24 @@ func (c *Config) GetAddress() string {
 	return fmt.Sprintf("%s:%v", c.Host, c.Port)
 }
 
+// GetDisplayURLs returns the human-facing URLs the server is reachable at:
+// always a localhost URL, plus a LAN URL unless the server is only bound
+// to a loopback address.
+func (c *Config) GetDisplayURLs() []string {
+	urls := []string{fmt.Sprintf("http://localhost:%d", c.Port)}
+	switch c.Host {
+	case "127.0.0.1", "localhost", "::1":
+		return urls
+	case "0.0.0.0", "":
+		if ip, err := utils.GetLocalIP(); err == nil {
+			urls = append(urls, fmt.Sprintf("http://%s:%d", ip, c.Port))
+		}
+	default:
+		urls = append(urls, fmt.Sprintf("http://%s:%d", c.Host, c.Port))
+	}
+	return urls
+}
+
 func ParseFromFlags() (*Config, error) {
 	port := flag.Int("port", defaultPort, portDesc)
 	host := flag.String("host", defaultHost, hostDesc)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -42,5 +44,42 @@ func TestGetAddress(t *testing.T) {
 	c := &Config{Host: "127.0.0.1", Port: 8080}
 	if got := c.GetAddress(); got != "127.0.0.1:8080" {
 		t.Errorf("GetAddress() = %q, want %q", got, "127.0.0.1:8080")
+	}
+}
+
+func TestGetDisplayURLsLoopback(t *testing.T) {
+	for _, host := range []string{"127.0.0.1", "localhost", "::1"} {
+		c := &Config{Host: host, Port: 8080}
+		urls := c.GetDisplayURLs()
+		if len(urls) != 1 {
+			t.Fatalf("host %q: got %d urls, want 1: %v", host, len(urls), urls)
+		}
+		if urls[0] != "http://localhost:8080" {
+			t.Errorf("host %q: urls[0] = %q, want %q", host, urls[0], "http://localhost:8080")
+		}
+	}
+}
+
+func TestGetDisplayURLsBindAll(t *testing.T) {
+	c := &Config{Host: "0.0.0.0", Port: 8080}
+	urls := c.GetDisplayURLs()
+	if len(urls) < 1 || urls[0] != "http://localhost:8080" {
+		t.Fatalf("urls[0] = %v, want first entry http://localhost:8080", urls)
+	}
+	if len(urls) == 2 {
+		if !strings.HasPrefix(urls[1], "http://") || !strings.HasSuffix(urls[1], ":8080") {
+			t.Errorf("urls[1] = %q, want format http://<ip>:8080", urls[1])
+		}
+	} else if len(urls) != 1 {
+		t.Fatalf("got %d urls, want 1 or 2: %v", len(urls), urls)
+	}
+}
+
+func TestGetDisplayURLsExplicitHost(t *testing.T) {
+	c := &Config{Host: "192.168.1.5", Port: 8080}
+	urls := c.GetDisplayURLs()
+	want := []string{"http://localhost:8080", "http://192.168.1.5:8080"}
+	if fmt.Sprint(urls) != fmt.Sprint(want) {
+		t.Errorf("GetDisplayURLs() = %v, want %v", urls, want)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -91,6 +91,9 @@ func NewServer(cfg *config.Config) *Server {
 
 func (s *Server) Start() error {
 	addr := s.config.GetAddress()
-	fmt.Printf("Serving %v on %v\n", s.config.Directory, addr)
+	fmt.Printf("Serving %v\n", s.config.Directory)
+	for _, url := range s.config.GetDisplayURLs() {
+		fmt.Printf("  %s\n", url)
+	}
 	return http.ListenAndServe(addr, s.mux)
 }

--- a/internal/utils/network.go
+++ b/internal/utils/network.go
@@ -1,0 +1,13 @@
+package utils
+
+import "net"
+
+// GetLocalIP returns the machine's outbound-facing LAN IP address.
+func GetLocalIP() (string, error) {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).IP.String(), nil
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"image"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,4 +31,15 @@ func TestHttpLogErr(t *testing.T) {
 func TestFFmpegExists(t *testing.T) {
 	// Result depends on the host; just assert it does not panic and returns a bool.
 	_ = FFmpegExists()
+}
+
+func TestGetLocalIP(t *testing.T) {
+	ip, err := GetLocalIP()
+	if err != nil {
+		// No network available in this environment; nothing more to assert.
+		return
+	}
+	if net.ParseIP(ip) == nil {
+		t.Errorf("GetLocalIP() = %q, not a valid IP", ip)
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes #24: startup now prints `http://localhost:<port>` and, unless the server is bound to loopback only, the machine's LAN IP as a second clickable link — instead of the unusable literal `0.0.0.0:<port>`.
- Adds `utils.GetLocalIP()` (LAN IP via the standard UDP-dial trick, no packets actually sent) and `Config.GetDisplayURLs()`, which `Server.Start()` now prints.

## Test plan
- [x] `go build -v ./...`
- [x] `go test -v -race ./...`
- [x] Manually ran the binary bound to `0.0.0.0` — confirmed both `http://localhost:<port>` and `http://<lan-ip>:<port>` are printed
- [x] Manually ran the binary bound to `127.0.0.1` — confirmed only the localhost link is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)