### PR TITLE
Show version and link to repo in footer

### DIFF
--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -85,7 +85,13 @@
       <div class="divider" style="margin-top: 2rem"></div>
       <footer class="text-center text-gray" style="padding: 1rem 0">
         <p>
-          heheserver gallery - a dynamic gallery able to be setup in any
+          <a
+            href="https://github.com/wsand02/heheserver"
+            target="_blank"
+            rel="noopener noreferrer"
+            >heheserver</a
+          >
+          gallery {{ version }} - a dynamic gallery able to be setup in any
           directory at any moment
         </p>
       </footer>

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"net/http"
 	"net/url"
+
+	"github.com/wsand02/heheserver/internal/version"
 )
 
 //go:embed *.html
@@ -63,7 +65,8 @@ var templates = template.Must(template.New("").Funcs(template.FuncMap{"sub": sub
 	"ge":      ge,
 	"le":      le,
 	"pageURL": pageURL,
-	"seq":     seq}).ParseFS(templatesFS, "*.html"))
+	"seq":     seq,
+	"version": version.GetVersion}).ParseFS(templatesFS, "*.html"))
 
 func RenderTemplate(w http.ResponseWriter, tmpl string, ctx any) {
 	err := templates.ExecuteTemplate(w, tmpl+".html", ctx)


### PR DESCRIPTION
## Summary
- Add a `version` template func (backed by the existing `internal/version.GetVersion()`) and render it in the shared footer.
- Turn the "heheserver" footer text into a link to the GitHub repo.

## Test plan
- [x] `go build -v ./...`
- [x] `go test -v -race ./...`
- [x] Ran the server locally (`-g -r`) and confirmed the footer on both the list and post pages shows the version string and a working link to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)