### PR TITLE
Refresh README for gallery features and fix -resize description

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,21 @@ Primarily intended for quick file sharing on trusted local networks. It does not
 authentication or other security features required for safe exposure to the public internet.
 
 ## Features
-- Lightweight HTTP file server
-- `.heheignore` support for hiding files
-- Optional embedded image gallery
+- Lightweight, read-only HTTP file server
 - Single static binary
+- `.heheignore` file omission — matching files are hidden from every directory index *and* made un-openable, as if they don't exist
+- Optional embedded gallery for images, video, and audio, with thumbnails and a single-item post view
+- Pagination for large directories
+- Optional on-the-fly image resizing (pure-Go fallback, accelerated by ffmpeg when present)
+- Video thumbnails when ffmpeg is available
+
+## Requirements
+
+Go is all you need to build and run heheserver.
+
+[ffmpeg](https://ffmpeg.org/) is an **optional** dependency: if it's on your `PATH`, it's used
+to accelerate image resizing and to generate video thumbnails. Without it, image resizing still
+works via a pure-Go fallback and video thumbnails are simply disabled.
 
 ## Installation
 
@@ -48,7 +59,7 @@ heheserver [options] [path]
 
 `-g` or `-gallery` Enables the embedded gallery page. (default omitted => false)
 
-`-r` or `-resize` Enables the experimental image resizing endpoint, requires ffmpeg on path. (default omitted => false)
+`-r` or `-resize` Enables the image resizing endpoint. Uses ffmpeg if it's on your `PATH`, otherwise a pure-Go fallback. When ffmpeg is present this also enables video thumbnails. (default omitted => false)
 
 `-s` or `-split` Max items per page for gallery pagination. (default 64)
 
@@ -58,6 +69,19 @@ heheserver [options] [path]
 
 `-vidtcache` Size of video thumbnail cache in megabytes, approximate. (default 1000)
 
+## Startup output
+
+On launch heheserver prints its version and the URLs it's reachable at — a `localhost` link
+plus, when bound to all interfaces, a LAN link — so you can click straight through from the
+terminal:
+
+```
+heheserver vX.X.X
+Serving ./
+  http://localhost:3400
+  http://192.168.1.42:3400
+```
+
 ## Heheignore
 Basically just gitignore, but omits matching files from all directory indexes while also making the files appear as if they don't exist when you try to access them.
 
@@ -66,7 +90,23 @@ Files are only read once so if you change a heheignore file that has already bee
 Supports subdirectory heheignore files.
 
 ## Gallery view
-W.I.P.
+
+Enable the gallery with `-g`. Instead of the plain directory listing, heheserver renders a
+thumbnail grid of the current directory with breadcrumb navigation. Images, video, and audio
+are recognised and previewed inline; clicking an item opens a single-item post view for it.
+Large directories are paginated (`-s` controls items per page). The gallery respects
+`.heheignore`, so omitted files never appear.
+
+Add `-r` to enable on-the-fly image resizing (used for thumbnails). If ffmpeg is on your
+`PATH`, video thumbnails are generated too; otherwise image resizing falls back to a pure-Go
+implementation and video thumbnails are skipped. The current version is shown in the footer,
+linking back to this repository.
+
+Supported types:
+
+- **Images:** `.jpg` `.jpeg` `.png` `.webp` `.svg` (resizable: `.jpg` `.jpeg` `.png`)
+- **Video:** `.mov` `.mp4` `.m4v` `.webm`
+- **Audio:** `.mp3` `.wav` `.ogg` `.m4a`
 
 ## License
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,7 @@ const (
 	defaultHost              string = "0.0.0.0"
 	galleryDesc              string = "Enables the embedded gallery page."
 	defaultGalleryFlag       bool   = false
-	resizeDesc               string = "Enables the experimental image resizing endpoint, requires ffmpeg on path."
+	resizeDesc               string = "Enables the image resizing endpoint (uses ffmpeg if present, otherwise a pure-Go fallback); also enables video thumbnails when ffmpeg is on PATH."
 	defaultSplit             int    = 64
 	splitDesc                string = "Max items per page for gallery pagination."
 	defaultResizeFlag        bool   = false


### PR DESCRIPTION
Brings the README in line with the current feature set ahead of a version bump.

## What changed
- **Features / Gallery view**: documents that the gallery serves images, video, and audio with thumbnails and a single-item post view; replaces the stale "W.I.P." section; adds a supported-types list and pagination note.
- **`-resize` accuracy**: image resizing has a pure-Go fallback — ffmpeg only *accelerates* it and additionally enables video thumbnails. Removes the misleading "requires ffmpeg on path" wording from both the README and the flag's `-help` string (`internal/config/config.go`).
- **Requirements**: documents ffmpeg as an optional dependency.
- **Startup output**: notes that the server prints its version and clickable localhost/LAN URLs (example uses a `vX.X.X` placeholder so there's no version to keep in sync).

Docs-only apart from the one-line flag help-string fix; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)