### PR TITLE
Fix potential nil-pointer panic in version.GetVersion

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,14 +1,24 @@
 package version
 
 import (
-	"fmt"
 	"runtime/debug"
 )
 
+// unknownVersion is returned when build info is unavailable (for example when
+// the binary was not built as a module).
+const unknownVersion = "unknown"
+
 func GetVersion() string {
 	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		fmt.Println("idk")
+	return versionFrom(info, ok)
+}
+
+// versionFrom derives the version string from the result of
+// debug.ReadBuildInfo. It is split out so the ok == false / nil-info path can
+// be tested without depending on how the test binary was built.
+func versionFrom(info *debug.BuildInfo, ok bool) string {
+	if !ok || info == nil || info.Main.Version == "" {
+		return unknownVersion
 	}
 	return info.Main.Version
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,52 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestVersionFrom(t *testing.T) {
+	tests := []struct {
+		name string
+		info *debug.BuildInfo
+		ok   bool
+		want string
+	}{
+		{
+			// Regression: ReadBuildInfo returning ok == false yields a nil
+			// *BuildInfo. Dereferencing it used to panic.
+			name: "unavailable build info",
+			info: nil,
+			ok:   false,
+			want: unknownVersion,
+		},
+		{
+			name: "empty version",
+			info: &debug.BuildInfo{Main: debug.Module{Version: ""}},
+			ok:   true,
+			want: unknownVersion,
+		},
+		{
+			name: "tagged version",
+			info: &debug.BuildInfo{Main: debug.Module{Version: "v1.2.3"}},
+			ok:   true,
+			want: "v1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := versionFrom(tt.info, tt.ok); got != tt.want {
+				t.Errorf("versionFrom(%v, %v) = %q, want %q", tt.info, tt.ok, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetVersionDoesNotPanic(t *testing.T) {
+	// In the test binary ReadBuildInfo generally succeeds; this just guards
+	// that GetVersion never panics and always returns something.
+	if got := GetVersion(); got == "" {
+		t.Error("GetVersion() returned empty string")
+	}
+}


### PR DESCRIPTION
`debug.ReadBuildInfo()` returns a nil `*BuildInfo` when its `ok` return is `false`, but `GetVersion` printed `"idk"` and then dereferenced `info.Main.Version` anyway — a latent nil-pointer panic on that path.

## Fix
- Return a sentinel `"unknown"` when build info is unavailable (and also when `Main.Version` is empty, e.g. some local builds).
- Extract `versionFrom(info, ok)` so the failure path is unit-testable without depending on how the test binary was built.
- Drop the stray `fmt.Println("idk")`.

## Tests
Adds `internal/version/version_test.go` covering the nil/`!ok` regression, the empty-version case, the tagged-version case, and a guard that `GetVersion()` never panics / returns empty. `go test -race ./...` passes.