### PR TITLE
Add gallery filtering (type / filename / extension) with realtime + no-JS fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-`heheserver` is a read-only HTTP file server written in Go. Its distinguishing features are `.heheignore` support (gitignore-style file omission that also makes ignored files un-openable) and an optional embedded image/video gallery with thumbnailing. It's meant for quick sharing on trusted local networks — there is deliberately no authentication.
+`heheserver` is a read-only HTTP file server written in Go. Its distinguishing features are `.heheignore` support (gitignore-style file omission that also makes ignored files un-openable) and an optional embedded image/video gallery with thumbnailing and filtering. It's meant for quick sharing on trusted local networks — there is deliberately no authentication.
 
 ## Commands
 
@@ -26,7 +26,7 @@ Entry point `main.go` → `config.ParseFromFlags()` → `server.NewServer(cfg)` 
 
 **Request flow depends on the `-gallery` flag** (`internal/server/server.go` `setupRoutes`):
 - Gallery **off**: a single `http.FileServer(hfs)` serves everything.
-- Gallery **on**: `/fs/` serves raw files, `/` renders the directory listing, `/post/` renders a single-item view, and (with `-resize`) `/resize/` and `/vidthumb/` serve generated thumbnails.
+- Gallery **on**: `/fs/` serves raw files, `/` renders the directory listing (and accepts the `?type=`/`?q=`/`?ext=` filter params), `/post/` renders a single-item view, and (with `-resize`) `/resize/` and `/vidthumb/` serve generated thumbnails.
 
 **Handlers receive state via a closure injector.** Gallery handlers don't match the standard `http.HandlerFunc` signature — they take `(w, r, path, *fs.HeheFS, *config.Config)`. `Server.makeHfsInjector` wraps them, pulling the target path from the `?path=` query parameter (defaulting to `/`). When editing routes/handlers, keep this signature and register through `makeHfsInjector`.
 
@@ -38,11 +38,13 @@ Entry point `main.go` → `config.ParseFromFlags()` → `server.NewServer(cfg)` 
 
 **Thumbnailing** (`internal/resize`, `internal/vidthumb`, plus the matching handlers): prefers shelling out to `ffmpeg` when it's on PATH (`utils.FFmpegExists()` is checked once at config time into `Config.FFmpegExists`). Image resize falls back to a pure-Go `golang.org/x/image/draw` path when ffmpeg is absent; video thumbnails require ffmpeg and the route is only registered when it exists.
 
-**View layer**: `internal/models/gallery.go` (`GalleryItem` with type predicates like `IsImage`/`IsVideo` and URL builders) feeds `internal/templates` (Go `html/template` files embedded via `//go:embed *.html`). Custom template funcs for pagination/arithmetic live in `templates.go`.
+**Gallery filtering** is server-side and applied *before* pagination in `GalleryHandler` (`internal/handlers/gallery.go`). `parseGalleryFilter` reads `?type=` (repeatable: `image`/`video`/`audio`/`dir`/`other`), `?q=` (case-insensitive filename substring), and `?ext=` (comma-separated) into a `models.GalleryFilter`; `Filter.Matches` AND-combines them, reusing `GalleryItem.TypeCategory()` (which is built on the `Is*` predicates). Filtering the whole directory before splitting into pages is deliberate — it keeps results correct across pagination/infinite scroll, unlike client-side hiding which would only see loaded pages. **A filter that matches nothing must render an empty grid, never fall back to the unfiltered listing** (that fallback was a real bug). The active filter is threaded through the no-JS pagination links (`GalleryContext.PageURL`) and the infinite-scroll `path` function via `data-type`/`data-query`/`data-ext` on `.grid`. In the browser, filtering is realtime: `base.html` debounces the filter form, refetches the same endpoint, and swaps `#gallery-results` in place (destroying/re-initializing Masonry + Infinite Scroll each time); the plain GET form is the no-JS fallback.
+
+**View layer**: `internal/models/gallery.go` (`GalleryItem` with type predicates like `IsImage`/`IsVideo`, `TypeCategory`, the `GalleryFilter` type, and URL builders) feeds `internal/templates` (Go `html/template` files embedded via `//go:embed *.html`). `GalleryContext` (in the handler) carries filter state and exposes the URL/checkbox helpers (`PageURL`, `TypeChecked`, `TypesParam`, `ClearURL`) the templates call. Custom template funcs for pagination/arithmetic live in `templates.go`.
 
 ## Conventions and gotchas
 
 - **Path handling is security-sensitive.** URL/query path escaping is centralized in `models.escapeQueryPath`/`escapeURLPath`; the fs and vidthumb handlers replicate Go stdlib's `Open` localization logic (`path.Clean`, `filepath.Localize`) to avoid traversal. Preserve this when touching path construction — emoji/special-character filenames have already caused 404 regressions.
-- Templates use `html/template`, so output is contextually auto-escaped (user-controlled filenames render as inert text, not live HTML). This does **not** replace the manual URL escaping: the URL builders (`escapeQueryPath`/`escapeURLPath`, `BreadcrumbToUrl`, `pageURL`) do the semantic query-value vs. path-segment encoding, and `html/template` preserves those already-escaped `%XX` values while adding HTML-context escaping on top. Keep both layers.
+- Templates use `html/template`, so output is contextually auto-escaped (user-controlled filenames render as inert text, not live HTML). This does **not** replace the manual URL escaping: the URL builders (`escapeQueryPath`/`escapeURLPath`, `BreadcrumbToUrl`, `GalleryContext.PageURL`) do the semantic query-value vs. path-segment encoding, and `html/template` preserves those already-escaped `%XX` values while adding HTML-context escaping on top. Keep both layers.
 - New file-type support usually means updating the predicate methods on `GalleryItem` and the relevant template.
 - Start bug fixes with a failing test derived from the issue (see the race tests in `internal/ignore` and `internal/fs` for the pattern).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ heheserver [options] [path]
 
 `-r` or `-resize` Enables the image resizing endpoint. Uses ffmpeg if it's on your `PATH`, otherwise a pure-Go fallback. When ffmpeg is present this also enables video thumbnails. (default omitted => false)
 
-`-s` or `-split` Max items per page for gallery pagination. (default 64)
+`-s` or `-split` Max items per page for gallery pagination. (default 48)
 
 `-igncache` Size of ignore cache in megabytes, approximate. (default 16)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ authentication or other security features required for safe exposure to the publ
 - Single static binary
 - `.heheignore` file omission — matching files are hidden from every directory index *and* made un-openable, as if they don't exist
 - Optional embedded gallery for images, video, and audio, with thumbnails and a single-item post view
+- Filter the gallery by file type, filename, or extension — updates in realtime, with a no-JavaScript fallback
 - Pagination for large directories
 - Optional on-the-fly image resizing (pure-Go fallback, accelerated by ffmpeg when present)
 - Video thumbnails when ffmpeg is available
@@ -101,6 +102,18 @@ Add `-r` to enable on-the-fly image resizing (used for thumbnails). If ffmpeg is
 `PATH`, video thumbnails are generated too; otherwise image resizing falls back to a pure-Go
 implementation and video thumbnails are skipped. The current version is shown in the footer,
 linking back to this repository.
+
+### Filtering
+
+A filter bar above the grid narrows the current directory by **file type** (image / video /
+audio / folder / other), **filename** (case-insensitive substring), and **file extension**
+(comma-separated, e.g. `.png, .mp4`). Multiple filters combine with AND. Filtering is done on
+the server across the *whole* directory (not just the pages already loaded), so it stays
+correct for large directories and works together with pagination and infinite scroll.
+
+With JavaScript the results update in realtime as you type or toggle a checkbox, and the URL
+stays in sync so a filtered view is shareable and reloadable. With JavaScript disabled the same
+filter bar still works as a plain form — press **Apply** to reload the filtered listing.
 
 Supported types:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ const (
 	galleryDesc              string = "Enables the embedded gallery page."
 	defaultGalleryFlag       bool   = false
 	resizeDesc               string = "Enables the image resizing endpoint (uses ffmpeg if present, otherwise a pure-Go fallback); also enables video thumbnails when ffmpeg is on PATH."
-	defaultSplit             int    = 37
+	defaultSplit             int    = 48
 	splitDesc                string = "Max items per page for gallery pagination."
 	defaultResizeFlag        bool   = false
 	defaultIgnoreCacheSize   int64  = 16

--- a/internal/handlers/gallery.go
+++ b/internal/handlers/gallery.go
@@ -235,6 +235,21 @@ type PostContext struct {
 	models.GalleryItem
 }
 
+// GalleryURL is the listing URL for the directory containing this item. It backs
+// the "Back to gallery" link's no-JS fallback (with JS, the link prefers
+// history.back() so the exact filtered/scrolled gallery state is restored).
+// Here Path is the item's full path (e.g. "/folder/file.png"), so we strip the
+// trailing filename to get the directory.
+func (pc *PostContext) GalleryURL() string {
+	dir := "/"
+	if i := strings.LastIndex(strings.TrimSuffix(pc.Path, "/"), "/"); i >= 0 {
+		dir = pc.Path[:i+1]
+	}
+	q := url.Values{}
+	q.Set("path", dir)
+	return "?" + q.Encode()
+}
+
 func PostHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.HeheFS, config *config.Config) {
 	hf, err := hfs.Open(ctx)
 	if err != nil {

--- a/internal/handlers/gallery.go
+++ b/internal/handlers/gallery.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	iofs "io/fs"
-
 	"github.com/wsand02/heheserver/internal/config"
 	"github.com/wsand02/heheserver/internal/fs"
 	"github.com/wsand02/heheserver/internal/models"
@@ -23,6 +21,116 @@ type GalleryContext struct {
 	Path         string
 	CurrentPage  int
 	MaxPage      int
+	Filter       models.GalleryFilter
+	FilterQuery  string // raw ?q= echo, to refill the search input
+	FilterExt    string // raw ?ext= echo, to refill the extension input
+}
+
+// typeOrder is the stable rendering/serialization order for file-type
+// categories (checkboxes, data-type attribute, ?type= params).
+var typeOrder = []string{"image", "video", "audio", "dir", "other"}
+
+// TypeOptions returns the file-type categories offered in the filter bar.
+func (gc *GalleryContext) TypeOptions() []string {
+	return typeOrder
+}
+
+// TypeChecked reports whether file-type category t is active, for rendering
+// checkbox checked state in the filter bar.
+func (gc *GalleryContext) TypeChecked(t string) bool {
+	return gc.Filter.Types[t]
+}
+
+// ClearURL is the current directory with all filters removed (the "Clear" link).
+func (gc *GalleryContext) ClearURL() string {
+	q := url.Values{}
+	if gc.Path != "" {
+		q.Set("path", gc.Path)
+	}
+	if len(q) == 0 {
+		return "?"
+	}
+	return "?" + q.Encode()
+}
+
+// activeTypes returns the active file-type categories in stable order.
+func (gc *GalleryContext) activeTypes() []string {
+	if len(gc.Filter.Types) == 0 {
+		return nil
+	}
+	var out []string
+	for _, t := range typeOrder {
+		if gc.Filter.Types[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// TypesParam joins the active file-type categories with commas for the grid's
+// data-type attribute, which infinite scroll reads to carry the filter forward.
+func (gc *GalleryContext) TypesParam() string {
+	return strings.Join(gc.activeTypes(), ",")
+}
+
+// PageURL builds the gallery URL for the given page number, preserving the
+// active filter params so the no-JS pagination links keep the filter applied.
+func (gc *GalleryContext) PageURL(page int) string {
+	q := url.Values{}
+	if gc.Path != "" {
+		q.Set("path", gc.Path)
+	}
+	if page > 1 { // omit p=1 for a cleaner URL
+		q.Set("p", strconv.Itoa(page))
+	}
+	for _, t := range gc.activeTypes() {
+		q.Add("type", t)
+	}
+	if gc.FilterQuery != "" {
+		q.Set("q", gc.FilterQuery)
+	}
+	if gc.FilterExt != "" {
+		q.Set("ext", gc.FilterExt)
+	}
+	if len(q) == 0 {
+		return "?"
+	}
+	return "?" + q.Encode()
+}
+
+// parseGalleryFilter reads the filter params (?type=, ?q=, ?ext=) from the
+// request into a models.GalleryFilter. Unknown type values are ignored;
+// extensions are normalized to a lowercased leading-dot form.
+func parseGalleryFilter(r *http.Request) models.GalleryFilter {
+	q := r.URL.Query()
+	f := models.GalleryFilter{}
+
+	valid := map[string]bool{"image": true, "video": true, "audio": true, "dir": true, "other": true}
+	for _, t := range q["type"] {
+		if valid[t] {
+			if f.Types == nil {
+				f.Types = map[string]bool{}
+			}
+			f.Types[t] = true
+		}
+	}
+
+	f.Query = strings.ToLower(strings.TrimSpace(q.Get("q")))
+
+	for _, e := range strings.Split(q.Get("ext"), ",") {
+		e = strings.ToLower(strings.TrimSpace(e))
+		if e == "" {
+			continue
+		}
+		if !strings.HasPrefix(e, ".") {
+			e = "." + e
+		}
+		if f.Exts == nil {
+			f.Exts = map[string]bool{}
+		}
+		f.Exts[e] = true
+	}
+	return f
 }
 
 // GetBreadcrumbs returns the non-empty path segments. Splitting on "/" yields
@@ -63,10 +171,26 @@ func GalleryHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.
 		utils.HttpLogErr(w, err, "Error reading dir", http.StatusInternalServerError)
 		return
 	}
-	var divided [][]iofs.FileInfo
-	for i := 0; i < len(dirlis); i += config.Split {
-		divided = append(divided, dirlis[i:min(i+config.Split, len(dirlis))])
+
+	filter := parseGalleryFilter(r)
+
+	// Build the gallery items, applying the filter before pagination so the
+	// whole directory is filtered rather than just the pages already loaded.
+	var items []models.GalleryItem
+	for _, item := range dirlis {
+		gi := models.GalleryItem{Filename: item.Name(), IsDir: item.IsDir(), Size: item.Size(), ModTime: item.ModTime(), Path: ctx}
+		if filter.Active() && !filter.Matches(&gi) {
+			continue
+		}
+		items = append(items, gi)
 	}
+
+	// Paginate the (filtered) items.
+	var divided [][]models.GalleryItem
+	for i := 0; i < len(items); i += config.Split {
+		divided = append(divided, items[i:min(i+config.Split, len(items))])
+	}
+
 	q := r.URL.Query().Get("p")
 	if q == "" {
 		q = "1"
@@ -77,23 +201,33 @@ func GalleryHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.
 		return
 	}
 	pid -= 1
-	if pid > len(divided) || pid < 0 {
+
+	gc := GalleryContext{
+		Resize:       config.Resize,
+		FFmpegExists: config.FFmpegExists,
+		Path:         ctx,
+		CurrentPage:  pid + 1,
+		MaxPage:      len(divided),
+		Filter:       filter,
+		FilterQuery:  strings.TrimSpace(r.URL.Query().Get("q")),
+		FilterExt:    strings.TrimSpace(r.URL.Query().Get("ext")),
+	}
+
+	if pid < 0 || pid >= len(divided) {
+		// An empty result (empty directory, or a filter that matched nothing)
+		// is a valid page 1 with zero items — never fall back to the unfiltered
+		// listing. Any other out-of-range page is a bad request.
+		if pid == 0 && len(divided) == 0 {
+			gc.CurrentPage = 1
+			gc.MaxPage = 1
+			templates.RenderTemplate(w, "list", &gc)
+			return
+		}
 		utils.HttpLogErr(w, fmt.Errorf("p: %d out of range", pid), "p out of range", http.StatusBadRequest)
 		return
 	}
-	var gc GalleryContext
-	if len(divided) == 0 {
-		divided = append(divided, dirlis)
-	}
-	for _, item := range divided[pid] {
-		gc.Items = append(gc.Items, models.GalleryItem{Filename: item.Name(), IsDir: item.IsDir(), Size: item.Size(), ModTime: item.ModTime(), Path: ctx})
-	}
-	gc.Resize = config.Resize
-	gc.FFmpegExists = config.FFmpegExists
-	gc.Path = ctx
-	gc.CurrentPage = pid + 1
-	gc.MaxPage = len(divided)
 
+	gc.Items = divided[pid]
 	templates.RenderTemplate(w, "list", &gc)
 }
 

--- a/internal/handlers/gallery_render_test.go
+++ b/internal/handlers/gallery_render_test.go
@@ -54,6 +54,27 @@ func TestListNestedBreadcrumbs(t *testing.T) {
 	}
 }
 
+// TestListHasResultsWrapper guards the realtime-filter swap target: the grid,
+// status, and pagination must live inside #gallery-results (and the filter form
+// must stay outside it, so its focused input survives a swap).
+func TestListHasResultsWrapper(t *testing.T) {
+	gc := &GalleryContext{Path: "/", CurrentPage: 1, MaxPage: 1}
+	body := renderList(t, gc)
+
+	if !strings.Contains(body, `id="gallery-results"`) {
+		t.Fatal("missing #gallery-results swap container")
+	}
+	formIdx := strings.Index(body, `class="filter-bar"`)
+	resultsIdx := strings.Index(body, `id="gallery-results"`)
+	gridIdx := strings.Index(body, `class="grid"`)
+	if formIdx == -1 || formIdx > resultsIdx {
+		t.Error("filter form must render before (outside) #gallery-results")
+	}
+	if gridIdx < resultsIdx {
+		t.Error("grid must render inside #gallery-results")
+	}
+}
+
 // TestListEscapesFilename is the reason for the html/template switch: a
 // user-controlled filename containing markup must be rendered as inert text, not
 // injected as live HTML.

--- a/internal/handlers/gallery_test.go
+++ b/internal/handlers/gallery_test.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/wsand02/heheserver/internal/cache"
 	"github.com/wsand02/heheserver/internal/config"
 	"github.com/wsand02/heheserver/internal/fs"
+	"github.com/wsand02/heheserver/internal/models"
 )
 
 func TestGetBreadcrumbs(t *testing.T) {
@@ -97,6 +99,128 @@ func TestGalleryHandlerEmptyDir(t *testing.T) {
 	GalleryHandler(w, r, "/", hfs, cfg)
 	if w.Code != 200 {
 		t.Errorf("empty dir: status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// mixedDir creates a temp dir with one file of each relevant type and returns it.
+func mixedDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range []string{"cat.png", "dog.jpg", "clip.mp4", "song.ogg", "notes.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// itemNames renders the gallery for target and returns which of the known
+// filenames appear in the output body.
+func galleryBody(t *testing.T, hfs *fs.HeheFS, cfg *config.Config, target string) (int, string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", target, nil)
+	GalleryHandler(w, r, "/", hfs, cfg)
+	return w.Code, w.Body.String()
+}
+
+func TestGalleryHandlerFilter(t *testing.T) {
+	hfs := testHFS(t, mixedDir(t))
+	cfg := &config.Config{Split: 64}
+
+	cases := []struct {
+		name       string
+		target     string
+		wantIn     []string
+		wantNotIn  []string
+	}{
+		{
+			name:      "type image",
+			target:    "/?path=/&type=image",
+			wantIn:    []string{"cat.png", "dog.jpg"},
+			wantNotIn: []string{"clip.mp4", "song.ogg", "notes.txt", ">sub<"},
+		},
+		{
+			name:      "type video and audio",
+			target:    "/?path=/&type=video&type=audio",
+			wantIn:    []string{"clip.mp4", "song.ogg"},
+			wantNotIn: []string{"cat.png", "notes.txt"},
+		},
+		{
+			name:      "query substring",
+			target:    "/?path=/&q=cat",
+			wantIn:    []string{"cat.png"},
+			wantNotIn: []string{"dog.jpg", "clip.mp4"},
+		},
+		{
+			name:      "extension",
+			target:    "/?path=/&ext=mp4",
+			wantIn:    []string{"clip.mp4"},
+			wantNotIn: []string{"cat.png", "song.ogg"},
+		},
+		{
+			name:      "AND image + query",
+			target:    "/?path=/&type=image&q=dog",
+			wantIn:    []string{"dog.jpg"},
+			wantNotIn: []string{"cat.png", "clip.mp4"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code, body := galleryBody(t, hfs, cfg, c.target)
+			if code != 200 {
+				t.Fatalf("status = %d, want 200 (body: %s)", code, body)
+			}
+			for _, w := range c.wantIn {
+				if !strings.Contains(body, w) {
+					t.Errorf("expected %q in body", w)
+				}
+			}
+			for _, w := range c.wantNotIn {
+				if strings.Contains(body, w) {
+					t.Errorf("did not expect %q in body", w)
+				}
+			}
+		})
+	}
+}
+
+// TestGalleryHandlerFilterEmptyResult guards the fixed fallback bug: a filter
+// that matches nothing must render an empty gallery, NOT the whole directory.
+func TestGalleryHandlerFilterEmptyResult(t *testing.T) {
+	dir := t.TempDir()
+	// image-only directory
+	if err := os.WriteFile(filepath.Join(dir, "cat.png"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	hfs := testHFS(t, dir)
+	cfg := &config.Config{Split: 64}
+
+	code, body := galleryBody(t, hfs, cfg, "/?path=/&type=video")
+	if code != 200 {
+		t.Fatalf("status = %d, want 200 (body: %s)", code, body)
+	}
+	if strings.Contains(body, "cat.png") {
+		t.Errorf("empty filter result fell back to showing unfiltered files (found cat.png)")
+	}
+}
+
+// TestGalleryPageURLKeepsFilter checks pagination links carry the active filter.
+func TestGalleryPageURLKeepsFilter(t *testing.T) {
+	gc := &GalleryContext{
+		Path:        "/pics/",
+		FilterQuery: "cat",
+		FilterExt:   "png",
+		Filter:      models.GalleryFilter{Types: map[string]bool{"image": true}},
+	}
+	got := gc.PageURL(2)
+	for _, want := range []string{"path=%2Fpics%2F", "p=2", "type=image", "q=cat", "ext=png"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PageURL(2) = %q, missing %q", got, want)
+		}
 	}
 }
 

--- a/internal/handlers/gallery_test.go
+++ b/internal/handlers/gallery_test.go
@@ -224,6 +224,23 @@ func TestGalleryPageURLKeepsFilter(t *testing.T) {
 	}
 }
 
+func TestPostContextGalleryURL(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/folder/file.png", "?path=%2Ffolder%2F"},
+		{"/file.png", "?path=%2F"},
+		{"/a/b/c.mp4", "?path=%2Fa%2Fb%2F"},
+	}
+	for _, c := range cases {
+		pc := &PostContext{models.GalleryItem{Path: c.path}}
+		if got := pc.GalleryURL(); got != c.want {
+			t.Errorf("GalleryURL(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
 func TestPostHandler(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hi"), 0644); err != nil {

--- a/internal/models/gallery.go
+++ b/internal/models/gallery.go
@@ -48,6 +48,51 @@ func (gi *GalleryItem) IsAudio() bool {
 		return false
 	}
 }
+// TypeCategory classifies the item into a single filter bucket:
+// "dir", "image", "video", "audio", or "other". It is the single source of
+// truth for type-based filtering, built on the Is* predicates above.
+func (gi *GalleryItem) TypeCategory() string {
+	switch {
+	case gi.IsDir:
+		return "dir"
+	case gi.IsImage():
+		return "image"
+	case gi.IsVideo():
+		return "video"
+	case gi.IsAudio():
+		return "audio"
+	default:
+		return "other"
+	}
+}
+
+// GalleryFilter narrows a directory listing. An empty field means "no
+// constraint" for that dimension; active constraints combine with AND.
+type GalleryFilter struct {
+	Types map[string]bool // TypeCategory values to keep; empty = all
+	Query string          // lowercased filename substring; "" = no filter
+	Exts  map[string]bool // normalized ".png" extension keys; empty = all
+}
+
+// Active reports whether any filter dimension is set.
+func (f GalleryFilter) Active() bool {
+	return len(f.Types) > 0 || f.Query != "" || len(f.Exts) > 0
+}
+
+// Matches reports whether gi satisfies every active filter dimension.
+func (f GalleryFilter) Matches(gi *GalleryItem) bool {
+	if len(f.Types) > 0 && !f.Types[gi.TypeCategory()] {
+		return false
+	}
+	if f.Query != "" && !strings.Contains(strings.ToLower(gi.Filename), f.Query) {
+		return false
+	}
+	if len(f.Exts) > 0 && !f.Exts[strings.ToLower(filepath.Ext(gi.Filename))] {
+		return false
+	}
+	return true
+}
+
 func (gi *GalleryItem) IsResizable() bool {
 	ext := strings.ToLower(filepath.Ext(gi.Filename))
 	switch ext {

--- a/internal/models/gallery_test.go
+++ b/internal/models/gallery_test.go
@@ -2,6 +2,84 @@ package models
 
 import "testing"
 
+func TestGalleryItem_TypeCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		isDir    bool
+		want     string
+	}{
+		{"dir", "photos", true, "dir"},
+		{"image", "cat.png", false, "image"},
+		{"video", "clip.mp4", false, "video"},
+		{"audio", "song.ogg", false, "audio"},
+		{"other", "notes.txt", false, "other"},
+		// a directory named like an image is still a dir
+		{"dir with image ext", "album.png", true, "dir"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gi := GalleryItem{Filename: tt.filename, IsDir: tt.isDir}
+			if got := gi.TypeCategory(); got != tt.want {
+				t.Errorf("TypeCategory() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGalleryFilter_Active(t *testing.T) {
+	tests := []struct {
+		name string
+		f    GalleryFilter
+		want bool
+	}{
+		{"empty", GalleryFilter{}, false},
+		{"types", GalleryFilter{Types: map[string]bool{"image": true}}, true},
+		{"query", GalleryFilter{Query: "cat"}, true},
+		{"exts", GalleryFilter{Exts: map[string]bool{".png": true}}, true},
+		{"empty maps", GalleryFilter{Types: map[string]bool{}, Exts: map[string]bool{}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.f.Active(); got != tt.want {
+				t.Errorf("Active() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGalleryFilter_Matches(t *testing.T) {
+	img := GalleryItem{Filename: "Cat.PNG"}
+	vid := GalleryItem{Filename: "clip.mp4"}
+	dir := GalleryItem{Filename: "album", IsDir: true}
+
+	tests := []struct {
+		name string
+		f    GalleryFilter
+		gi   GalleryItem
+		want bool
+	}{
+		{"empty matches all", GalleryFilter{}, img, true},
+		{"type image matches image", GalleryFilter{Types: map[string]bool{"image": true}}, img, true},
+		{"type image rejects video", GalleryFilter{Types: map[string]bool{"image": true}}, vid, false},
+		{"type dir matches dir", GalleryFilter{Types: map[string]bool{"dir": true}}, dir, true},
+		{"query case-insensitive substring", GalleryFilter{Query: "cat"}, img, true},
+		{"query no match", GalleryFilter{Query: "dog"}, img, false},
+		{"ext with dot matches (case-insensitive)", GalleryFilter{Exts: map[string]bool{".png": true}}, img, true},
+		{"ext no match", GalleryFilter{Exts: map[string]bool{".jpg": true}}, img, false},
+		{"AND: type and query both pass", GalleryFilter{Types: map[string]bool{"image": true}, Query: "cat"}, img, true},
+		{"AND: type passes but query fails", GalleryFilter{Types: map[string]bool{"image": true}, Query: "dog"}, img, false},
+		{"AND: type and ext conflict -> no match", GalleryFilter{Types: map[string]bool{"image": true}, Exts: map[string]bool{".mp4": true}}, img, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.f.Matches(&tt.gi); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGalleryItem_SizeMB(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -112,6 +112,41 @@
       a:visited {
         color: #23b0ff;
       }
+      /* Gallery filter bar. */
+      .filter-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: flex-end;
+        margin: 1rem 0 1.5rem;
+        padding: 1rem;
+        border: 1px solid rgba(128, 128, 128, 0.25);
+        border-radius: 0.3rem;
+      }
+      .filter-field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+      .filter-label {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: gray;
+      }
+      .filter-types {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+      .filter-type {
+        margin: 0;
+        text-transform: capitalize;
+      }
+      .filter-actions {
+        display: flex;
+        gap: 0.4rem;
+      }
     </style>
   </head>
   <body>
@@ -169,18 +204,30 @@
         if (document.querySelector(".pagination__next")) {
           var dirPath = grid.getAttribute("data-path") || "";
           var startPage = parseInt(grid.getAttribute("data-page"), 10) || 1;
+          // Active filters, carried forward so later pages stay filtered.
+          var filterType = grid.getAttribute("data-type") || "";
+          var filterQuery = grid.getAttribute("data-query") || "";
+          var filterExt = grid.getAttribute("data-ext") || "";
           new InfiniteScroll(grid, {
             // Build the next-page URL explicitly from the real page number.
             // A selector/template path makes Infinite Scroll hunt for "the
             // number" in the URL, but digits inside percent-encoded path
             // segments (e.g. %2F, %3F) fool that heuristic and corrupt ?path=.
             path: function () {
-              return (
+              var url =
                 "?path=" +
                 encodeURIComponent(dirPath) +
                 "&p=" +
-                (startPage + this.loadCount + 1)
-              );
+                (startPage + this.loadCount + 1);
+              // data-type is a comma-joined list; emit one type= per value.
+              if (filterType) {
+                filterType.split(",").forEach(function (t) {
+                  url += "&type=" + encodeURIComponent(t);
+                });
+              }
+              if (filterQuery) url += "&q=" + encodeURIComponent(filterQuery);
+              if (filterExt) url += "&ext=" + encodeURIComponent(filterExt);
+              return url;
             },
             checkLastPage: ".pagination__next", // stop when a page has no Next link
             status: ".page-load-status", // loading / end / error indicator

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -190,53 +190,147 @@
     <script src="/static/infinite-scroll.pkgd.min.js"></script>
     <script>
       (function () {
-        var grid = document.querySelector(".grid");
-        if (!grid) return; // post.html shares base — no grid there
-        var msnry = new Masonry(grid, {
-          itemSelector: ".grid-item",
-          columnWidth: ".grid-sizer",
-          gutter: ".gutter-sizer",
-          percentPosition: true,
-        });
-        imagesLoaded(grid).on("progress", function () {
-          msnry.layout();
-        });
-        if (document.querySelector(".pagination__next")) {
-          var dirPath = grid.getAttribute("data-path") || "";
-          var startPage = parseInt(grid.getAttribute("data-page"), 10) || 1;
-          // Active filters, carried forward so later pages stay filtered.
-          var filterType = grid.getAttribute("data-type") || "";
-          var filterQuery = grid.getAttribute("data-query") || "";
-          var filterExt = grid.getAttribute("data-ext") || "";
-          new InfiniteScroll(grid, {
-            // Build the next-page URL explicitly from the real page number.
-            // A selector/template path makes Infinite Scroll hunt for "the
-            // number" in the URL, but digits inside percent-encoded path
-            // segments (e.g. %2F, %3F) fool that heuristic and corrupt ?path=.
-            path: function () {
-              var url =
-                "?path=" +
-                encodeURIComponent(dirPath) +
-                "&p=" +
-                (startPage + this.loadCount + 1);
-              // data-type is a comma-joined list; emit one type= per value.
-              if (filterType) {
-                filterType.split(",").forEach(function (t) {
-                  url += "&type=" + encodeURIComponent(t);
-                });
-              }
-              if (filterQuery) url += "&q=" + encodeURIComponent(filterQuery);
-              if (filterExt) url += "&ext=" + encodeURIComponent(filterExt);
-              return url;
-            },
-            checkLastPage: ".pagination__next", // stop when a page has no Next link
-            status: ".page-load-status", // loading / end / error indicator
-            append: ".grid-item",
-            outlayer: msnry, // appended items get imagesLoaded + masonry.appended()
-            history: false,
-            hideNav: ".pagination", // hide server pagination once JS drives loading
+        var container = document.getElementById("gallery-results");
+        if (!container) return; // post.html shares base — no results grid there
+
+        // The filter form lives outside #gallery-results, so it survives the
+        // realtime swap and its focused input keeps focus while typing.
+        var form = document.querySelector(".filter-bar");
+        var msnry = null;
+        var infScroll = null;
+
+        // (Re)initialize masonry + infinite scroll on the current grid. Called
+        // on first load and after every realtime results swap.
+        function initGallery() {
+          var grid = container.querySelector(".grid");
+          if (!grid) return;
+          msnry = new Masonry(grid, {
+            itemSelector: ".grid-item",
+            columnWidth: ".grid-sizer",
+            gutter: ".gutter-sizer",
+            percentPosition: true,
           });
+          imagesLoaded(grid).on("progress", function () {
+            msnry.layout();
+          });
+          if (container.querySelector(".pagination__next")) {
+            var dirPath = grid.getAttribute("data-path") || "";
+            var startPage = parseInt(grid.getAttribute("data-page"), 10) || 1;
+            // Applied filters (from the server-rendered grid), carried forward
+            // so later infinite-scroll pages stay filtered.
+            var filterType = grid.getAttribute("data-type") || "";
+            var filterQuery = grid.getAttribute("data-query") || "";
+            var filterExt = grid.getAttribute("data-ext") || "";
+            infScroll = new InfiniteScroll(grid, {
+              // Build the next-page URL explicitly from the real page number.
+              // A selector/template path makes Infinite Scroll hunt for "the
+              // number" in the URL, but digits inside percent-encoded path
+              // segments (e.g. %2F, %3F) fool that heuristic and corrupt ?path=.
+              path: function () {
+                var url =
+                  "?path=" +
+                  encodeURIComponent(dirPath) +
+                  "&p=" +
+                  (startPage + this.loadCount + 1);
+                // data-type is a comma-joined list; emit one type= per value.
+                if (filterType) {
+                  filterType.split(",").forEach(function (t) {
+                    url += "&type=" + encodeURIComponent(t);
+                  });
+                }
+                if (filterQuery) url += "&q=" + encodeURIComponent(filterQuery);
+                if (filterExt) url += "&ext=" + encodeURIComponent(filterExt);
+                return url;
+              },
+              checkLastPage: ".pagination__next", // stop when a page has no Next link
+              status: ".page-load-status", // loading / end / error indicator
+              append: ".grid-item",
+              outlayer: msnry, // appended items get imagesLoaded + masonry.appended()
+              history: false,
+              hideNav: ".pagination", // hide server pagination once JS drives loading
+            });
+          }
         }
+
+        // Tear down the current instances before swapping in new results, so we
+        // don't leak listeners or stack duplicate InfiniteScroll watchers.
+        function destroyGallery() {
+          if (infScroll) {
+            infScroll.destroy();
+            infScroll = null;
+          }
+          if (msnry) {
+            msnry.destroy();
+            msnry = null;
+          }
+        }
+
+        // Build a page-1 gallery URL from the live filter form.
+        function formURL() {
+          var params = new URLSearchParams();
+          params.set("path", form.elements["path"].value);
+          Array.prototype.forEach.call(
+            form.querySelectorAll('input[name="type"]:checked'),
+            function (cb) {
+              params.append("type", cb.value);
+            }
+          );
+          var q = form.elements["q"].value.trim();
+          if (q) params.set("q", q);
+          var ext = form.elements["ext"].value.trim();
+          if (ext) params.set("ext", ext);
+          return "?" + params.toString();
+        }
+
+        // Realtime refetch: pull the filtered gallery and swap in its results.
+        // A token guards against out-of-order responses (fast typing).
+        var refetchToken = 0;
+        function refilter() {
+          if (!form) return;
+          var url = formURL();
+          var token = ++refetchToken;
+          container.setAttribute("aria-busy", "true");
+          fetch(url, { headers: { "X-Requested-With": "fetch" } })
+            .then(function (r) {
+              return r.text();
+            })
+            .then(function (html) {
+              if (token !== refetchToken) return; // superseded by a newer request
+              var doc = new DOMParser().parseFromString(html, "text/html");
+              var fresh = doc.getElementById("gallery-results");
+              if (!fresh) return;
+              destroyGallery();
+              container.innerHTML = fresh.innerHTML;
+              initGallery();
+              container.removeAttribute("aria-busy");
+              // Keep the address bar in sync so the filtered view is shareable
+              // and reloadable. replaceState (not push) avoids a history entry
+              // per keystroke.
+              history.replaceState(null, "", url);
+            })
+            .catch(function () {
+              if (token === refetchToken) container.removeAttribute("aria-busy");
+            });
+        }
+
+        var debounceTimer;
+        function debouncedRefilter() {
+          clearTimeout(debounceTimer);
+          debounceTimer = setTimeout(refilter, 200);
+        }
+
+        if (form) {
+          // The form still submits normally with JS disabled (no-JS fallback).
+          form.addEventListener("submit", function (e) {
+            e.preventDefault();
+            clearTimeout(debounceTimer);
+            refilter();
+          });
+          // input fires for both text fields (per keystroke) and checkboxes.
+          form.addEventListener("input", debouncedRefilter);
+        }
+
+        initGallery();
       })();
     </script>
   </body>

--- a/internal/templates/list.html
+++ b/internal/templates/list.html
@@ -8,7 +8,41 @@
   {{ end }}
 </ul>
 
-<div class="grid" data-path="{{ .Path }}" data-page="{{ .CurrentPage }}">
+<form method="get" class="filter-bar">
+  <input type="hidden" name="path" value="{{ .Path }}" />
+  <div class="filter-field">
+    <span class="filter-label">Type</span>
+    <div class="filter-types">
+      {{ range $t := .TypeOptions }}
+      <label class="form-checkbox filter-type">
+        <input type="checkbox" name="type" value="{{ $t }}" {{ if $.TypeChecked $t }}checked{{ end }} />
+        <i class="form-icon"></i> {{ $t }}
+      </label>
+      {{ end }}
+    </div>
+  </div>
+  <div class="filter-field">
+    <span class="filter-label">Search</span>
+    <input class="form-input" type="text" name="q" value="{{ .FilterQuery }}" placeholder="filename" />
+  </div>
+  <div class="filter-field">
+    <span class="filter-label">Extension</span>
+    <input class="form-input" type="text" name="ext" value="{{ .FilterExt }}" placeholder=".png, .mp4" />
+  </div>
+  <div class="filter-actions">
+    <button type="submit" class="btn btn-primary">Apply</button>
+    <a href="{{ .ClearURL }}" class="btn">Clear</a>
+  </div>
+</form>
+
+<div
+  class="grid"
+  data-path="{{ .Path }}"
+  data-page="{{ .CurrentPage }}"
+  data-type="{{ .TypesParam }}"
+  data-query="{{ .FilterQuery }}"
+  data-ext="{{ .FilterExt }}"
+>
   <div class="grid-sizer"></div>
   <div class="gutter-sizer"></div>
   {{ range .Items }}
@@ -80,6 +114,10 @@
   {{ end }}
 </div>
 
+{{ if not .Items }}
+<p class="text-gray text-center" style="padding: 2rem 0">No matching files</p>
+{{ end }}
+
 <!-- Infinite Scroll status (hidden until JS drives loading; no-JS uses the pagination below). -->
 <div class="page-load-status" aria-live="polite">
   <div class="infinite-scroll-request">
@@ -94,7 +132,7 @@
   <!-- Previous -->
   {{ if gt .CurrentPage 1 }}
   <li class="page-item">
-    <a href="{{ pageURL .Path (sub .CurrentPage 1) }}" aria-label="Previous">
+    <a href="{{ $.PageURL (sub .CurrentPage 1) }}" aria-label="Previous">
       <i class="icon icon-arrow-left"></i>
     </a>
   </li>
@@ -109,21 +147,21 @@
   sub $currentPage 2 }} {{ $end := add $currentPage 2 }} {{ if lt $start 1
   }}{{ $start = 1 }}{{ end }} {{ if gt $end $maxPage }}{{ $end = $maxPage }}{{
   end }} {{ if gt $start 2 }}
-  <li class="page-item"><a href="{{ pageURL .Path 1 }}">1</a></li>
+  <li class="page-item"><a href="{{ $.PageURL 1 }}">1</a></li>
   {{ if gt $start 3 }}<li class="page-item disabled"><span>...</span></li>{{ end }}
   {{ end }} {{ range $i := seq $start $end }} {{ if eq $i $currentPage }}
   <li class="page-item active"><a>{{ $i }}</a></li>
   {{ else }}
-  <li class="page-item"><a href="{{ pageURL $.Path $i }}">{{ $i }}</a></li>
+  <li class="page-item"><a href="{{ $.PageURL $i }}">{{ $i }}</a></li>
   {{ end }} {{ end }} {{ if lt $end (sub $maxPage 1) }} {{ if lt $end (sub
   $maxPage 2) }}<li class="page-item disabled"><span>...</span></li>{{ end }}
-  <li class="page-item"><a href="{{ pageURL .Path $maxPage }}">{{ $maxPage }}</a></li>
+  <li class="page-item"><a href="{{ $.PageURL $maxPage }}">{{ $maxPage }}</a></li>
   {{ end }}
 
   <!-- Next -->
   {{ if lt .CurrentPage .MaxPage }}
   <li class="page-item">
-    <a href="{{ pageURL .Path (add .CurrentPage 1) }}" class="pagination__next" aria-label="Next">
+    <a href="{{ $.PageURL (add .CurrentPage 1) }}" class="pagination__next" aria-label="Next">
       <i class="icon icon-arrow-right"></i>
     </a>
   </li>

--- a/internal/templates/list.html
+++ b/internal/templates/list.html
@@ -35,6 +35,10 @@
   </div>
 </form>
 
+<!-- Swappable results region: realtime filtering refetches the gallery and
+     replaces this container's contents (see base.html). The filter form above
+     stays put so the focused input keeps focus while typing. -->
+<div id="gallery-results">
 <div
   class="grid"
   data-path="{{ .Path }}"
@@ -171,4 +175,6 @@
   </li>
   {{ end }}
 </ul>
-{{ end }} {{ template "footer" . }}
+{{ end }}
+</div>
+{{ template "footer" . }}

--- a/internal/templates/post.html
+++ b/internal/templates/post.html
@@ -2,9 +2,15 @@
 
 <div class="columns">
   <div class="column col-8 col-md-12 col-mx-auto">
-    <!-- Back navigation -->
+    <!-- Back navigation. Real href to the containing directory is the no-JS
+         (and open-in-new-tab) fallback; with JS and real history, prefer
+         history.back() so the exact filtered/scrolled gallery is restored. -->
     <div class="mb-2">
-      <a href="javascript:history.back()" class="btn btn-link">
+      <a
+        href="{{ .GalleryURL }}"
+        class="btn btn-link"
+        onclick="if(history.length>1){history.back();return false;}"
+      >
         <i class="icon icon-back"></i> Back to gallery
       </a>
     </div>

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -2,11 +2,9 @@ package templates
 
 import (
 	"embed"
-	"fmt"
 	"html/template"
 	"io/fs"
 	"net/http"
-	"net/url"
 
 	"github.com/wsand02/heheserver/internal/version"
 )
@@ -34,19 +32,6 @@ func gt(a, b int) bool { return a > b }
 func lt(a, b int) bool { return a < b }
 func ge(a, b int) bool { return a >= b }
 func le(a, b int) bool { return a <= b }
-func pageURL(path string, page int) string {
-	q := url.Values{}
-	if path != "" {
-		q.Set("path", path)
-	}
-	if page > 1 { // optionally omit p=1 for cleaner URL
-		q.Set("p", fmt.Sprintf("%d", page))
-	}
-	if len(q) == 0 {
-		return "?"
-	}
-	return "?" + q.Encode()
-}
 
 // seq returns a slice of ints from start to end inclusive
 func seq(start, end int) []int {
@@ -66,7 +51,6 @@ var templates = template.Must(template.New("").Funcs(template.FuncMap{"sub": sub
 	"lt":      lt,
 	"ge":      ge,
 	"le":      le,
-	"pageURL": pageURL,
 	"seq":     seq,
 	"version": version.GetVersion}).ParseFS(templatesFS, "*.html"))
 

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -5,32 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 )
-
-func TestPageURL(t *testing.T) {
-	cases := []struct {
-		path string
-		page int
-		want string
-	}{
-		{"", 1, "?"},
-		{"", 2, "?p=2"},
-		{"foo/bar", 1, "?path=foo%2Fbar"},
-	}
-	for _, c := range cases {
-		if got := pageURL(c.path, c.page); got != c.want {
-			t.Errorf("pageURL(%q, %d) = %q, want %q", c.path, c.page, got, c.want)
-		}
-	}
-
-	// Ordering of query values is not guaranteed, so assert on substrings.
-	got := pageURL("foo", 3)
-	if !strings.Contains(got, "path=foo") || !strings.Contains(got, "p=3") {
-		t.Errorf("pageURL(%q, %d) = %q, want it to contain path=foo and p=3", "foo", 3, got)
-	}
-}
 
 func TestSeq(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## What

Adds **filtering** to the gallery view. A filter bar above the grid narrows the current directory by:

- **File type** — image / video / audio / folder / other (checkboxes, repeatable `?type=`)
- **Filename** — case-insensitive substring (`?q=`)
- **File extension** — comma-separated, e.g. `.png, .mp4` (`?ext=`)

Multiple filters combine with **AND**.

## How

- **Server-side, before pagination.** `GalleryHandler` filters the whole directory into `[]GalleryItem` before splitting into pages, so results stay correct across pagination and infinite scroll — unlike client-side hiding, which only sees already-loaded pages. Type matching reuses the existing `Is*` predicates via a new `GalleryItem.TypeCategory()`; `GalleryFilter.Matches` AND-combines the three dimensions.
- **Realtime in the browser, with a no-JS fallback.** The filter bar is a plain GET form (the fallback — press **Apply** to reload). With JS, `base.html` debounces input (200ms), refetches the same endpoint, and swaps `#gallery-results` in place, tearing down and re-initializing Masonry + Infinite Scroll each time. The address bar stays in sync (`replaceState`) so a filtered view is shareable/reloadable.
- **Filter threads through pagination + infinite scroll.** No-JS pagination links carry the filter via `GalleryContext.PageURL`; infinite scroll reads it from `data-type`/`data-query`/`data-ext` on `.grid`.

## Fixes along the way

- **Empty-result bug:** the old `len(divided) == 0` fallback rendered the *entire* directory; a zero-match filter now correctly shows an empty grid with "No matching files" (never falls back to unfiltered).
- **Post "Back to gallery" link** used `href="javascript:history.back()"`, which is dead with JS off and gives no real URL in a new tab. Now a real href to the containing directory (`PostContext.GalleryURL`), with `history.back()` still preferred via `onclick` when real history exists.
- **Default `-split`** set to 48 (was 37 in code / 64 in the README) — cleaner across the masonry breakpoints and the docs now match.

## Tests

- `GalleryFilter.Matches` / `TypeCategory` unit tests (type buckets, case-insensitive `q`, `ext` with/without dot, AND-combination, empty-matches-all).
- `GalleryHandler` tests: per-filter behavior, AND, the empty-result-doesn't-leak case, `PageURL` filter preservation, `PostContext.GalleryURL`, and a `#gallery-results` wrapper regression guard.
- Full `go build -v ./...` + `go test -race ./...` green; inline JS syntax-checked; verified end-to-end against a running server (JS runtime swap to be confirmed in a browser).

## Docs

README (Features + new Filtering subsection) and CLAUDE.md (architecture, view layer, stale `pageURL` reference) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)