### PR TITLE
Fix grammar in footer text

### DIFF
--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -180,7 +180,7 @@
             rel="noopener noreferrer"
             >heheserver</a
           >
-          gallery {{ version }} - a dynamic gallery able to be setup in any
+          gallery {{ version }} - a dynamic gallery able to be set up in any
           directory at any moment
         </p>
       </footer>


### PR DESCRIPTION
## Summary
- Fix "able to be setup" → "able to be set up" in the gallery footer ("setup" is a noun, "set up" is the verb form)

## Test plan
- Visual only; no functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)