### PR TITLE
Remove ineffective loading=lazy on gallery thumbnails

### DIFF
--- a/internal/templates/list.html
+++ b/internal/templates/list.html
@@ -61,7 +61,6 @@
           src="{{ .GetUrl }}"
           {{ end }}
           alt="{{ .Filename }}"
-          loading="lazy"
         />
       </div>
       {{ else if .IsVideo }}


### PR DESCRIPTION
## Summary
- Gallery thumbnails were rendered with `loading="lazy"`, a remnant from before Masonry/imagesLoaded/Infinite Scroll were wired in.
- `imagesLoaded` already force-fetches every grid image via a hidden proxy `Image` to know when to run Masonry layout, so native lazy-loading gave no bandwidth benefit — but the real `<img>` could still render natively-lazy well after the proxy resolved, popping in late with no follow-up layout call and overlapping neighboring cards.
- This showed up as thumbnails "stacked like playing cards" on small screens (e.g. iPhone), where more images sit below the fold at load time.

## Test plan
- [x] `go build && go test -v -race ./...`
- [x] Load the gallery on a narrow viewport (~390px), scroll through several infinite-scroll pages, confirm thumbnails lay out without overlapping
- [x] Spot-check desktop width still lays out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)