### PR TITLE
Improve gallery video playback: inline, single-tap, loop, real aspect ratio

### DIFF
--- a/internal/handlers/gallery_render_test.go
+++ b/internal/handlers/gallery_render_test.go
@@ -130,6 +130,41 @@ func TestListSpecialCharURLsNotBroken(t *testing.T) {
 	}
 }
 
+// TestListVideoAttributes guards the grid <video> playback attributes: videos
+// must play inline (playsinline), loop, and preload metadata so a single tap
+// plays and real dimensions are available for aspect-ratio sizing. The invalid
+// loading="lazy" (a no-op on <video>) must be gone.
+func TestListVideoAttributes(t *testing.T) {
+	gc := &GalleryContext{
+		Items:       []models.GalleryItem{{Filename: "clip.mp4", Path: "/"}},
+		CurrentPage: 1,
+		MaxPage:     1,
+	}
+	body := renderList(t, gc)
+
+	for _, attr := range []string{"playsinline", "loop", `preload="metadata"`} {
+		if !strings.Contains(body, attr) {
+			t.Errorf("grid video missing %q, got:\n%s", attr, body)
+		}
+	}
+	if strings.Contains(body, `loading="lazy"`) {
+		t.Errorf("grid video still has invalid loading=\"lazy\", got:\n%s", body)
+	}
+}
+
+// TestPostVideoAttributes guards the single-item view's <video>: it should also
+// play inline and loop, consistent with the grid.
+func TestPostVideoAttributes(t *testing.T) {
+	pc := &PostContext{models.GalleryItem{Filename: "clip.mp4", Path: "/clip.mp4"}}
+	body := renderPost(t, pc)
+
+	for _, attr := range []string{"playsinline", "loop"} {
+		if !strings.Contains(body, attr) {
+			t.Errorf("post video missing %q, got:\n%s", attr, body)
+		}
+	}
+}
+
 // TestPostSpecialCharURLsNotBroken does the same guard for the single-item view.
 func TestPostSpecialCharURLsNotBroken(t *testing.T) {
 	pc := &PostContext{models.GalleryItem{Filename: "a b 😀.txt", Path: "/sub dir/"}}

--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -48,10 +48,14 @@
         max-height: 70vh;
         object-fit: contain;
       }
+      /* aspect-ratio here is only a placeholder box until the video's real
+         dimensions load (see the loadedmetadata handler in the gallery JS,
+         which overrides it per-video). object-fit:contain letterboxes rather
+         than cropping non-16:9 clips. */
       .media-cover {
         width: 100%;
         aspect-ratio: 16 / 9;
-        object-fit: cover;
+        object-fit: contain;
         background: #000;
       }
       /* Masonry fluid-percentage grid. Items float as a rough grid without JS;
@@ -213,6 +217,21 @@
           imagesLoaded(grid).on("progress", function () {
             msnry.layout();
           });
+          // imagesLoaded ignores <video>, so size video tiles to their real
+          // aspect ratio once metadata (not the whole file) loads and relayout.
+          // Capture phase because loadedmetadata doesn't bubble; one listener on
+          // the grid also catches infinite-scroll-appended videos.
+          grid.addEventListener(
+            "loadedmetadata",
+            function (e) {
+              var v = e.target;
+              if (v.tagName === "VIDEO" && v.videoWidth) {
+                v.style.aspectRatio = v.videoWidth + " / " + v.videoHeight;
+                if (msnry) msnry.layout();
+              }
+            },
+            true
+          );
           if (container.querySelector(".pagination__next")) {
             var dirPath = grid.getAttribute("data-path") || "";
             var startPage = parseInt(grid.getAttribute("data-page"), 10) || 1;

--- a/internal/templates/list.html
+++ b/internal/templates/list.html
@@ -67,8 +67,9 @@
       <div class="card-image">
         <video
           controls
-          preload="none"
-          loading="lazy"
+          loop
+          playsinline
+          preload="metadata"
           {{ if and $.Resize $.FFmpegExists }}
           poster="{{ .GetVidThumb }}"
           {{ end }}

--- a/internal/templates/post.html
+++ b/internal/templates/post.html
@@ -52,7 +52,7 @@
       </div>
       {{ else if .IsVideo }}
       <div class="card-image media-frame">
-        <video controls preload="metadata" class="media-contain" poster="">
+        <video controls loop playsinline preload="metadata" class="media-contain" poster="">
           <source src="{{ .GetPath }}" />
           Your browser does not support the video tag.
         </video>

--- a/internal/vidthumb/vidthumb.go
+++ b/internal/vidthumb/vidthumb.go
@@ -3,7 +3,6 @@ package vidthumb
 import (
 	"bytes"
 	"image"
-	"log"
 	"os/exec"
 )
 
@@ -21,7 +20,7 @@ func GenerateThumb(path string) (image.Image, error) {
 	}
 	img, _, err := image.Decode(&out)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	return img, nil
 }


### PR DESCRIPTION
## What & why

Gallery videos were awkward to use. This addresses four issues:

1. **Play inline** — added `playsinline` so tapping play on mobile (iOS especially) no longer forces fullscreen.
2. **Single-tap play** — grid videos used `preload="none"`, so the first tap only started loading and a second tap was needed to actually play (most noticeable on infinite-scroll-appended videos). Switched to `preload="metadata"` so one tap plays. Also removed the invalid `loading="lazy"` (a no-op on `<video>`).
3. **Loop** — videos now loop, in both the grid and the single-item post view.
4. **Real aspect ratio without downloading the video** — `.media-cover` now uses `object-fit: contain` (no cropping) and a capturing `loadedmetadata` listener on the grid sizes each video to its true dimensions and relays out Masonry. Capture phase (the event doesn't bubble) also catches infinite-scroll-appended videos with no extra wiring, and it works with or without ffmpeg since dimensions come from the video's own metadata rather than the poster thumbnail.

Also hardened `vidthumb`: a bad decoded frame now returns an error instead of `log.Fatal`, which previously would crash the whole server process.

## How to test

Run against a directory with a few videos, including at least one **portrait** clip and enough files to trigger infinite scroll:

```
go build && ./heheserver -g -r ./somedir
```

Then check:
- Tapping a grid video plays it **inline** (best on a phone / mobile emulation) and it **loops**.
- A **single tap plays** — including on videos revealed by scrolling.
- The portrait video shows its **true aspect ratio** (letterboxed, not cropped to 16:9); the grid reflows to the correct height after metadata loads.
- Works with ffmpeg present (poster thumbnails) and absent (`-r` off / no ffmpeg).

## Tests

Added `TestListVideoAttributes` / `TestPostVideoAttributes` (written failing first). `go build -v ./...` and `go test -race ./...` both pass.

> Note: the mobile inline-play / single-tap / reflow behavior needs a real browser to confirm end-to-end — hence this PR to make it easy to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)