### PR TITLE
Use glacialwisp navbar component for the site header

### DIFF
--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -29,12 +29,6 @@
         outline: 2px solid var(--color-primary, #23b0ff);
         outline-offset: 2px;
       }
-      .site-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: 1rem;
-      }
       /* Media sizing helpers (no glacialwisp equivalents). */
       .media-frame {
         display: flex;
@@ -151,17 +145,19 @@
   </head>
   <body>
     <div class="container grid-xl" style="padding: 1.5rem 0.5rem">
-      <header class="site-header">
-        <a href="/" class="h5" style="text-decoration: none">
-          heheserver gallery
-        </a>
-        <button
-          type="button"
-          class="btn btn-action"
-          id="theme-toggle"
-          aria-label="Toggle dark mode"
-          onclick="(function(){var h=document.documentElement;var n=h.getAttribute('data-theme')==='dark'?'light':'dark';h.setAttribute('data-theme',n);localStorage.setItem('theme',n);document.getElementById('theme-toggle').textContent=n==='dark'?'☀️':'🌙';})()"
-        ></button>
+      <header class="navbar" style="margin-bottom: 1rem">
+        <section class="navbar-section">
+          <a href="/" class="navbar-brand">heheserver gallery</a>
+        </section>
+        <section class="navbar-section">
+          <button
+            type="button"
+            class="btn btn-action"
+            id="theme-toggle"
+            aria-label="Toggle dark mode"
+            onclick="(function(){var h=document.documentElement;var n=h.getAttribute('data-theme')==='dark'?'light':'dark';h.setAttribute('data-theme',n);localStorage.setItem('theme',n);document.getElementById('theme-toggle').textContent=n==='dark'?'☀️':'🌙';})()"
+          ></button>
+        </section>
       </header>
       <script>
         // Match the toggle glyph to the active theme on load.


### PR DESCRIPTION
## What & why

Swap the hand-rolled `.site-header` flex layout for glacialwisp's built-in navbar component (`.navbar` / `.navbar-section` / `.navbar-brand`). Those classes are already in the bundled `glacialwisp.min.css`, so this adds zero new bytes — it just uses the design system instead of bespoke CSS and deletes the custom `.site-header` rule.

Layout is unchanged: brand on the left, theme toggle on the right (the last `.navbar-section` right-aligns itself).

## Note for review

The brand title goes from `.h5` (1rem) to `.navbar-brand` (0.9rem) — glacialwisp's default brand size. It's a ~10% shrink and drops the `h5` bottom margin. If you'd rather keep the larger title, say so and I'll pin the size.

## Testing

```
go build && ./heheserver -g ./somedir
```
Check the header renders the same (brand left, toggle right) in both light and dark themes and at mobile widths.

`go build -v ./...` and the template/handler tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)