### PR TITLE
Honor .heheignore negation across ignore files

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,11 +5,10 @@ import (
 	"log"
 
 	"github.com/dgraph-io/ristretto/v2"
-	ignore "github.com/wsand02/go-gitignore"
 )
 
 type IgnoreCache struct {
-	*ristretto.Cache[string, *ignore.GitIgnore]
+	*ristretto.Cache[string, []string]
 }
 
 var ignoreCache *IgnoreCache
@@ -47,7 +46,7 @@ func GetResizeCache() *ResizeCache {
 
 func NewIgnoreCache(size int64) error {
 	size, nc := sizeToNCMB(size)
-	cache, err := ristretto.NewCache(&ristretto.Config[string, *ignore.GitIgnore]{
+	cache, err := ristretto.NewCache(&ristretto.Config[string, []string]{
 		NumCounters: nc,   // 1000*10 seems ok for heheignore files...
 		MaxCost:     size, // 16MB
 		BufferItems: 64,

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -2,9 +2,8 @@ package cache
 
 import (
 	"image"
+	"slices"
 	"testing"
-
-	ignore "github.com/wsand02/go-gitignore"
 )
 
 func TestSizeToNCMB(t *testing.T) {
@@ -21,16 +20,16 @@ func TestIgnoreCacheRoundtrip(t *testing.T) {
 	if err := NewIgnoreCache(1); err != nil {
 		t.Fatal(err)
 	}
-	gi := ignore.CompileIgnoreLines("*.tmp")
+	lines := []string{"*.tmp", "!keep.tmp"}
 	c := GetIgnoreCache()
-	c.Set("key", gi, 1)
+	c.Set("key", lines, 1)
 	c.Wait() // ristretto applies Set asynchronously
 
 	got, ok := c.Get("key")
 	if !ok {
 		t.Fatal("expected cached ignore value, got miss")
 	}
-	if got != gi {
+	if !slices.Equal(got, lines) {
 		t.Error("cached ignore value differs from stored value")
 	}
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -36,7 +36,7 @@ func (hfs HeheFS) Open(name string) (http.File, error) {
 	if len(name) > 0 && name[0] == '/' {
 		normPath = name[1:]
 	}
-	if ignore.MatchesAny(rules, normPath) {
+	if ignore.Matches(rules, normPath) {
 		return nil, fs.ErrNotExist
 	}
 
@@ -65,6 +65,9 @@ func (h HeheFile) Readdir(count int) ([]os.FileInfo, error) {
 	if !ok {
 		return nil, errMissingReadDir
 	}
+	// Rules depend only on the directory being listed, so compute them once
+	// rather than per entry.
+	rules := ignore.GetIgnoreForPath(h.root, filepath.Join(h.root, h.currentPath))
 	var list []fs.FileInfo
 	for {
 		dirs, err := d.ReadDir(count - len(list))
@@ -74,13 +77,12 @@ func (h HeheFile) Readdir(count int) ([]os.FileInfo, error) {
 				// Pretend it doesn't exist, like (*os.File).Readdir does.
 				continue
 			}
-			rules := ignore.GetIgnoreForPath(h.root, filepath.Join(h.root, h.currentPath))
 			// Normalize path by removing leading slash for pattern matching
 			pathToCheck := filepath.Join(h.currentPath, info.Name())
 			if len(pathToCheck) > 0 && pathToCheck[0] == '/' {
 				pathToCheck = pathToCheck[1:]
 			}
-			if ignore.MatchesAny(rules, pathToCheck) {
+			if ignore.Matches(rules, pathToCheck) {
 				continue
 			}
 			list = append(list, info)

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -77,6 +77,49 @@ func TestSubDirectory(t *testing.T) {
 	defer file.Close()
 }
 
+func TestOpenNegatedAcrossFiles(t *testing.T) {
+	dir := t.TempDir()
+	cache.NewIgnoreCache(16)
+	os.WriteFile(filepath.Join(dir, ".heheignore"), []byte("*\n"), 0644)
+	subdir := filepath.Join(dir, "subdir")
+	os.Mkdir(subdir, 0755)
+	os.WriteFile(filepath.Join(subdir, ".heheignore"), []byte("!keep.txt\n"), 0644)
+	os.WriteFile(filepath.Join(subdir, "keep.txt"), []byte("keep"), 0644)
+	os.WriteFile(filepath.Join(subdir, "other.txt"), []byte("nope"), 0644)
+
+	hfs := Dir(dir)
+
+	keep, err := hfs.Open("subdir/keep.txt")
+	if err != nil {
+		t.Fatalf("expected subdir/keep.txt to be re-included by negation, got %v", err)
+	}
+	keep.Close()
+
+	if _, err := hfs.Open("subdir/other.txt"); err == nil {
+		t.Fatal("expected subdir/other.txt to remain ignored")
+	}
+}
+
+func TestOpenNegatedSameFile(t *testing.T) {
+	dir := t.TempDir()
+	cache.NewIgnoreCache(16)
+	os.WriteFile(filepath.Join(dir, ".heheignore"), []byte("*\n!keep.txt\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("keep"), 0644)
+	os.WriteFile(filepath.Join(dir, "other.txt"), []byte("nope"), 0644)
+
+	hfs := Dir(dir)
+
+	keep, err := hfs.Open("keep.txt")
+	if err != nil {
+		t.Fatalf("expected keep.txt to be re-included by negation, got %v", err)
+	}
+	keep.Close()
+
+	if _, err := hfs.Open("other.txt"); err == nil {
+		t.Fatal("expected other.txt to remain ignored")
+	}
+}
+
 func TestReaddirIgnoreFile(t *testing.T) {
 	dir := t.TempDir()
 	cache.NewIgnoreCache(16)

--- a/internal/ignore/ignore.go
+++ b/internal/ignore/ignore.go
@@ -1,36 +1,40 @@
 package ignore
 
 import (
+	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	ignore "github.com/wsand02/go-gitignore"
 	"github.com/wsand02/heheserver/internal/cache"
 )
 
-// getIgnoreForPath returns a slice of ignore rules for the specified path,
-// recursively traverses from root to the path appending all rules along the way.
-func GetIgnoreForPath(root, path string) []*ignore.GitIgnore {
+// GetIgnoreForPath returns the combined ignore rules for the specified path.
+// It walks from the target directory up to root, collecting each level's
+// .heheignore lines, then compiles them into a single GitIgnore ordered
+// root-first so that negation (!pattern) is honored across files, matching
+// gitignore's last-match-wins semantics.
+func GetIgnoreForPath(root, path string) *ignore.GitIgnore {
 	root = filepath.Clean(root)
 	dir := filepath.Clean(path)
 
-	var rules []*ignore.GitIgnore
+	var perDir [][]string
 
 	for {
-
-		ig, ok := cache.GetIgnoreCache().Get(dir)
-
+		lines, ok := cache.GetIgnoreCache().Get(dir)
 		if !ok {
-			var err error
-			ig, err = ignore.CompileIgnoreFile(filepath.Join(dir, ".heheignore"))
+			bs, err := os.ReadFile(filepath.Join(dir, ".heheignore"))
 			if err != nil {
-				ig = nil
+				lines = nil
+			} else {
+				lines = strings.Split(string(bs), "\n")
 			}
-			cache.GetIgnoreCache().Set(dir, ig, 1)
+			cache.GetIgnoreCache().Set(dir, lines, 1)
 		}
 
-		if ig != nil {
-			rules = append(rules, ig)
+		if lines != nil {
+			perDir = append(perDir, lines)
 		}
 
 		if dir == root || dir == "." || dir == "/" {
@@ -40,15 +44,22 @@ func GetIgnoreForPath(root, path string) []*ignore.GitIgnore {
 		dir = filepath.Dir(dir)
 	}
 
-	slices.Reverse(rules)
-	return rules
+	// perDir is deepest-first; reverse so the root file's lines come first.
+	slices.Reverse(perDir)
+
+	var all []string
+	for _, lines := range perDir {
+		all = append(all, lines...)
+	}
+
+	return ignore.CompileIgnoreLines(all...)
 }
 
-func MatchesAny(rules []*ignore.GitIgnore, path string) bool {
-	for _, r := range rules {
-		if r.MatchesPath(path) {
-			return true
-		}
+// Matches reports whether path is ignored by the combined rules. A nil ruleset
+// (no .heheignore anywhere up the tree) matches nothing.
+func Matches(rules *ignore.GitIgnore, path string) bool {
+	if rules == nil {
+		return false
 	}
-	return false
+	return rules.MatchesPath(path)
 }


### PR DESCRIPTION
## Problem

Ignoring everything (`*`) and then re-including a file with a negation (`!keep.txt`) returned "File does not exist" whenever the negation lived in a *different* `.heheignore` than the `*`.

`GetIgnoreForPath` compiled each directory's `.heheignore` into a *separate* `GitIgnore`, and `MatchesAny` OR-combined them — returning `true` as soon as any one file matched. Negation (`!`, last-match-wins) is only folded *within* a single compiled file, so an ancestor's `*` short-circuited to "ignored" and no negation in another file could ever re-include the path → `fs.ErrNotExist`.

## Fix

Collect each level's raw `.heheignore` lines (root-first, deepest-last) and compile them into **one** `GitIgnore`, matching once — restoring gitignore's cross-file negation semantics.

- `cache`: `IgnoreCache` now caches per-directory `[]string` lines instead of compiled `*GitIgnore`, so lines can be concatenated before compiling.
- `ignore`: `GetIgnoreForPath` returns a single combined `*GitIgnore`; `MatchesAny` replaced by `Matches`.
- `fs`: update both call sites; hoist the rules lookup out of the `Readdir` per-entry loop since it's invariant per directory.
- tests: added cross-file and same-file negation tests; updated cache test.

## Verification

`go build -v ./...` and `go test -race ./internal/fs ./internal/ignore ./internal/cache` pass. Manual end-to-end confirmed: with `*` at root and `!keep.txt` in a subdir, `keep.txt` serves 200 via `/fs/` while siblings 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)