### PR TITLE
Enrich error logs and add styled browser error pages

### DIFF
--- a/internal/handlers/gallery.go
+++ b/internal/handlers/gallery.go
@@ -162,13 +162,13 @@ func (gc *GalleryContext) BreadcrumbToUrl(i int) string {
 func GalleryHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.HeheFS, config *config.Config) {
 	hf, err := hfs.Open(ctx)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error opening file", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "open file", utils.StatusForErr(err))
 		return
 	}
 	defer hf.Close()
 	dirlis, err := hf.Readdir(-1)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error reading dir", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "read directory", http.StatusInternalServerError)
 		return
 	}
 
@@ -197,7 +197,7 @@ func GalleryHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.
 	}
 	pid, err := strconv.Atoi(q)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Query conversion failed", http.StatusBadRequest)
+		utils.HttpLogErr(w, r, err, "invalid page number", http.StatusBadRequest)
 		return
 	}
 	pid -= 1
@@ -223,7 +223,7 @@ func GalleryHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.
 			templates.RenderTemplate(w, "list", &gc)
 			return
 		}
-		utils.HttpLogErr(w, fmt.Errorf("p: %d out of range", pid), "p out of range", http.StatusBadRequest)
+		utils.HttpLogErr(w, r, fmt.Errorf("p: %d out of range", pid), "page out of range", http.StatusBadRequest)
 		return
 	}
 
@@ -253,17 +253,17 @@ func (pc *PostContext) GalleryURL() string {
 func PostHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.HeheFS, config *config.Config) {
 	hf, err := hfs.Open(ctx)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error opening file", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "open file", utils.StatusForErr(err))
 		return
 	}
 	defer hf.Close()
 	hfstat, err := hf.Stat()
 	if err != nil {
-		utils.HttpLogErr(w, err, "Failed to fetch file info", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "stat file", utils.StatusForErr(err))
 		return
 	}
 	if hfstat.IsDir() {
-		utils.HttpLogErr(w, fmt.Errorf("Directory on posthandler"), "This is a directory", http.StatusBadRequest)
+		utils.HttpLogErr(w, r, fmt.Errorf("directory on posthandler"), "this is a directory", http.StatusBadRequest)
 		return
 	}
 	templates.RenderTemplate(w, "post", &PostContext{models.GalleryItem{Filename: hfstat.Name(), IsDir: hfstat.IsDir(), Path: ctx, Size: hfstat.Size(), ModTime: hfstat.ModTime()}}) // oh well

--- a/internal/handlers/resize.go
+++ b/internal/handlers/resize.go
@@ -6,7 +6,6 @@ import (
 	"image/jpeg"
 	"image/png"
 	"io"
-	"log"
 	"net/http"
 	"path/filepath"
 
@@ -23,18 +22,17 @@ func ResizeHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.H
 	cImg, ok := cache.GetResizeCache().Get(ctx)
 	w.Header().Add("Cache-Control", "private, max-age=86400")
 	if ok {
-		log.Println("cached")
 		if cImg.Transparent {
 			err := png.Encode(w, cImg.Image)
 			if err != nil {
-				utils.HttpLogErr(w, err, "Error encoding cached png", http.StatusInternalServerError)
+				utils.HttpLogErr(w, r, err, "encode cached png", http.StatusInternalServerError)
 				return
 			}
 			return
 		}
 		err := jpeg.Encode(w, cImg.Image, nil)
 		if err != nil {
-			utils.HttpLogErr(w, err, "Error encoding cached jpeg", http.StatusInternalServerError)
+			utils.HttpLogErr(w, r, err, "encode cached jpeg", http.StatusInternalServerError)
 			return
 		}
 		return
@@ -42,7 +40,7 @@ func ResizeHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.H
 
 	hf, err := hfs.Open(ctx)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error opening file", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "open file", utils.StatusForErr(err))
 		return
 	}
 	defer hf.Close()
@@ -52,7 +50,7 @@ func ResizeHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.H
 	hf.Read(head)
 	hf.Seek(0, io.SeekStart)
 	if !filetype.IsImage(head) {
-		utils.HttpLogErr(w, fmt.Errorf("Not an image"), "Not an image", http.StatusUnsupportedMediaType)
+		utils.HttpLogErr(w, r, fmt.Errorf("not an image"), "not an image", http.StatusUnsupportedMediaType)
 		return
 	}
 
@@ -60,14 +58,12 @@ func ResizeHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.H
 
 	if cfg.FFmpegExists {
 		fullName := filepath.Join(hfs.Root, ctx)
-		fmt.Println(fullName)
 		dst, err = resize.ResizeImage(fullName)
 	} else {
-		log.Println("Resizing using fallback")
 		dst, err = resize.ResizeImageFallback(hf)
 	}
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error resizing image", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "resize image", http.StatusInternalServerError)
 		return
 	}
 
@@ -77,7 +73,7 @@ func ResizeHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.H
 	}, utils.GetCost(dst))
 	err = jpeg.Encode(w, dst, nil)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error encoding jpeg", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "encode jpeg", http.StatusInternalServerError)
 		return
 	}
 }

--- a/internal/handlers/vidthumb.go
+++ b/internal/handlers/vidthumb.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"fmt"
 	"image/jpeg"
-	"log"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -19,7 +18,7 @@ import (
 func VidThumbHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs.HeheFS, config *config.Config) {
 	hf, err := hfs.Open(ctx)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error opening file", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "open file", utils.StatusForErr(err))
 		return
 	}
 	defer hf.Close()
@@ -29,7 +28,7 @@ func VidThumbHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs
 	if ok {
 		err = jpeg.Encode(w, vtb, nil)
 		if err != nil {
-			utils.HttpLogErr(w, err, "Error encoding cached thumbnail", http.StatusInternalServerError)
+			utils.HttpLogErr(w, r, err, "encode cached thumbnail", http.StatusInternalServerError)
 			return
 		}
 		return
@@ -37,14 +36,9 @@ func VidThumbHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs
 	head := make([]byte, 512)
 	hf.Read(head)
 	if !filetype.IsVideo(head) {
-		utils.HttpLogErr(w, fmt.Errorf("Not a video"), "Not a video", http.StatusUnsupportedMediaType)
+		utils.HttpLogErr(w, r, fmt.Errorf("not a video"), "not a video", http.StatusUnsupportedMediaType)
 		return
 	}
-
-	hfstat, _ := hf.Stat()
-	log.Println(hfstat.Name())
-	// a := path.Clean(path.Clean("/" + ctx)[1:])
-	// a, _ = filepath.Localize(a)
 
 	// taken from fs.Open()
 	path := path.Clean("/" + ctx)[1:]
@@ -53,7 +47,7 @@ func VidThumbHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs
 	}
 	path, err = filepath.Localize(path)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "localize path", http.StatusInternalServerError)
 		return
 	}
 	dir := string(hfs.Root)
@@ -63,13 +57,13 @@ func VidThumbHandler(w http.ResponseWriter, r *http.Request, ctx string, hfs *fs
 	fullName := filepath.Join(dir, path)
 	img, err := vidthumb.GenerateThumb(fullName)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error generating thumbnail", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "generate thumbnail", http.StatusInternalServerError)
 		return
 	}
 	cache.GetVidThumbCache().Set(ctx, img, utils.GetCost(img))
 	err = jpeg.Encode(w, img, nil)
 	if err != nil {
-		utils.HttpLogErr(w, err, "Error encoding thumbnail", http.StatusInternalServerError)
+		utils.HttpLogErr(w, r, err, "encode thumbnail", http.StatusInternalServerError)
 		return
 	}
 }

--- a/internal/templates/error.html
+++ b/internal/templates/error.html
@@ -1,0 +1,10 @@
+{{ template "header" . }}
+<div class="columns">
+  <div class="column col-6 col-md-12 col-mx-auto text-center" style="padding: 3rem 0">
+    <h1 class="text-primary" style="font-size: 5rem; margin: 0">{{ .Code }}</h1>
+    <p class="h4">{{ .Status }}</p>
+    {{ if .Message }}<p class="text-gray">{{ .Message }}</p>{{ end }}
+    <a href="/" class="btn btn-primary mt-2">Back to gallery</a>
+  </div>
+</div>
+{{ template "footer" . }}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"html/template"
 	"io/fs"
+	"log"
 	"net/http"
 
 	"github.com/wsand02/heheserver/internal/version"
@@ -57,6 +58,26 @@ var templates = template.Must(template.New("").Funcs(template.FuncMap{"sub": sub
 func RenderTemplate(w http.ResponseWriter, tmpl string, ctx any) {
 	err := templates.ExecuteTemplate(w, tmpl+".html", ctx)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		// Rendering may have already written a partial body (and a 200 header),
+		// so we can't reliably swap in a styled error page here — just log it.
+		log.Printf("render template %q: %v", tmpl, err)
+		http.Error(w, "template error", http.StatusInternalServerError)
+	}
+}
+
+type errorContext struct {
+	Code    int
+	Status  string
+	Message string
+}
+
+// RenderError writes a glacialwisp-themed error page with the given status code
+// and detail message.
+func RenderError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(code)
+	ctx := errorContext{Code: code, Status: http.StatusText(code), Message: msg}
+	if err := templates.ExecuteTemplate(w, "error.html", ctx); err != nil {
+		log.Printf("render error page (%d): %v", code, err)
 	}
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -42,6 +43,24 @@ func TestArithmeticHelpers(t *testing.T) {
 	}
 	if !le(3, 3) || !le(3, 5) || le(5, 3) {
 		t.Error("le behaves incorrectly")
+	}
+}
+
+func TestRenderError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	RenderError(rec, http.StatusNotFound, "open file")
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"404", http.StatusText(http.StatusNotFound), "open file", "Back to gallery"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n%s", want, body)
+		}
 	}
 }
 

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,11 +1,29 @@
 package utils
 
 import (
+	"errors"
+	"io/fs"
 	"log"
 	"net/http"
+
+	"github.com/wsand02/heheserver/internal/templates"
 )
 
-func HttpLogErr(w http.ResponseWriter, err error, msg string, code int) {
-	log.Println(err.Error())
-	http.Error(w, msg, code)
+// HttpLogErr logs the failure with request context (status, method, requested
+// URL) and the underlying error, then renders a styled error page to the client.
+func HttpLogErr(w http.ResponseWriter, r *http.Request, err error, msg string, code int) {
+	log.Printf("[%d] %s %s — %s: %v", code, r.Method, r.URL.RequestURI(), msg, err)
+	templates.RenderError(w, code, msg)
+}
+
+// StatusForErr maps a filesystem error to an HTTP status code.
+func StatusForErr(err error) int {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return http.StatusNotFound
+	case errors.Is(err, fs.ErrPermission):
+		return http.StatusForbidden
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/internal/utils/http_test.go
+++ b/internal/utils/http_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"fmt"
+	"io/fs"
+	"net/http"
+	"testing"
+)
+
+func TestStatusForErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"not exist", fmt.Errorf("open x: %w", fs.ErrNotExist), http.StatusNotFound},
+		{"permission", fmt.Errorf("open x: %w", fs.ErrPermission), http.StatusForbidden},
+		{"generic", fmt.Errorf("boom"), http.StatusInternalServerError},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := StatusForErr(c.err); got != c.want {
+				t.Errorf("StatusForErr(%v) = %d, want %d", c.err, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -18,13 +19,14 @@ func TestGetCost(t *testing.T) {
 
 func TestHttpLogErr(t *testing.T) {
 	w := httptest.NewRecorder()
-	HttpLogErr(w, errors.New("boom"), "something failed", http.StatusBadRequest)
+	r := httptest.NewRequest(http.MethodGet, "/post/?path=/x.txt", nil)
+	HttpLogErr(w, r, errors.New("boom"), "something failed", http.StatusBadRequest)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
-	if body := w.Body.String(); body != "something failed\n" {
-		t.Errorf("body = %q, want %q", body, "something failed\n")
+	if body := w.Body.String(); !strings.Contains(body, "something failed") {
+		t.Errorf("body missing message %q: %s", "something failed", body)
 	}
 }
 


### PR DESCRIPTION
## Problem

Errors were unhelpful on both ends. Every handler funneled failures through `utils.HttpLogErr`, which logged only `err.Error()` — no method, requested URL, or operation — and returned a generic `500` even when a file was simply missing. Browser users got `http.Error`'s bare `text/plain` string: off-theme, with no way back.

## Changes

**Server logs**
- `utils.HttpLogErr` now takes the request and logs status, method, requested URL (which carries `?path=`), the operation, and the underlying error:
  ```
  [404] GET /post/?path=/secret.txt — open file: file does not exist
  ```
- Add `utils.StatusForErr`: `fs.ErrNotExist → 404`, `fs.ErrPermission → 403`, else `500`. Open/stat failures now use it, so **missing/ignored files return 404 instead of 500**.
- `RenderTemplate` now logs render failures instead of swallowing them.
- Dropped stray context-free debug prints (`fmt.Println(fullName)`, `log.Println("cached")` / `hfstat.Name()` / `"Resizing using fallback"`).

**Styled browser errors**
- New `internal/templates/error.html` + `templates.RenderError` render a glacialwisp-themed page reusing the shared header/footer, so it inherits the gallery theme and dark mode (big status code, status text, "Back to gallery" link). Because every handler routes through `HttpLogErr`, they all get it for free.

## Verification

`go build -v ./...` and `go test -race ./internal/utils ./internal/templates ./internal/handlers ./internal/fs` pass. New tests: `StatusForErr` mapping, `RenderError` page, updated `HttpLogErr`. Manual end-to-end: ignored/missing files return 404 with the themed page (`text/html`); valid files still 200.

_(Pre-existing `resize`/`vidthumb` `image: unknown format` test failures are unrelated to this change.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)